### PR TITLE
Fix signed assertions bug

### DIFF
--- a/lib/saml_idp/incoming_metadata.rb
+++ b/lib/saml_idp/incoming_metadata.rb
@@ -22,7 +22,10 @@ module SamlIdp
         ds: signature_namespace,
         md: metadata_namespace
       ).first
-      doc ? !!doc["WantAssertionsSigned"] : false
+      if (doc && !doc['WantAssertionsSigned'].nil?)
+        return doc['WantAssertionsSigned'].strip.downcase == 'true'
+      end
+      return false
     end
     hashable :sign_assertions
 


### PR DESCRIPTION
This code currently returns true if WantAssertionsSigned is present in the relying party metadata, rather than actually parsing the fields. This request is a simple bug fix.