### PR TITLE
Fix signed assertions bug

### DIFF
--- a/lib/saml_idp/incoming_metadata.rb
+++ b/lib/saml_idp/incoming_metadata.rb
@@ -22,7 +22,10 @@ module SamlIdp
         ds: signature_namespace,
         md: metadata_namespace
       ).first
-      doc ? !!doc["WantAssertionsSigned"] : false
+      if (doc && !doc['WantAssertionsSigned'].nil?)
+        return doc['WantAssertionsSigned'].strip.downcase == 'true'
+      end
+      return false
     end
     hashable :sign_assertions
 

--- a/spec/lib/saml_idp/incoming_metadata_spec.rb
+++ b/spec/lib/saml_idp/incoming_metadata_spec.rb
@@ -1,0 +1,41 @@
+require 'spec_helper'
+module SamlIdp
+
+  metadata_1 = <<-eos
+<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="test" entityID="https://test-saml.com/saml">
+  <md:SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol" AuthnRequestsSigned="true" WantAssertionsSigned="false">
+  </md:SPSSODescriptor>
+</md:EntityDescriptor>
+  eos
+
+  metadata_2 = <<-eos
+<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="test" entityID="https://test-saml.com/saml">
+  <md:SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol" AuthnRequestsSigned="true" WantAssertionsSigned="true">
+  </md:SPSSODescriptor>
+</md:EntityDescriptor>
+  eos
+
+  metadata_3 = <<-eos
+<md:EntityDescriptor xmlns:md="urn:oasis:names:tc:SAML:2.0:metadata" xmlns:saml="urn:oasis:names:tc:SAML:2.0:assertion" ID="test" entityID="https://test-saml.com/saml">
+  <md:SPSSODescriptor protocolSupportEnumeration="urn:oasis:names:tc:SAML:2.0:protocol" AuthnRequestsSigned="true">
+  </md:SPSSODescriptor>
+</md:EntityDescriptor>
+  eos
+
+  describe IncomingMetadata do
+    it 'should properly set sign_assertions to false' do
+      metadata = SamlIdp::IncomingMetadata.new(metadata_1)
+      expect(metadata.sign_assertions).to eq(false)
+    end
+
+    it 'should properly set sign_assertions to true' do
+      metadata = SamlIdp::IncomingMetadata.new(metadata_2)
+      expect(metadata.sign_assertions).to eq(true)
+    end
+
+    it 'should properly set sign_assertions to false when WantAssertionsSigned is not included' do
+      metadata = SamlIdp::IncomingMetadata.new(metadata_3)
+      expect(metadata.sign_assertions).to eq(false)
+    end
+  end
+end


### PR DESCRIPTION
This code currently returns true if WantAssertionsSigned is present in the relying party metadata, rather than actually parsing the fields. This request is a simple bug fix with some tests. 

The original pull request is here: https://github.com/saml-idp/saml_idp/pull/98. I did a force push to my forked branch, which closed the request and wouldn't allow me to reopen it.