### PR TITLE
Added NameIdPolicy support

### DIFF
--- a/lib/saml_idp/assertion_builder.rb
+++ b/lib/saml_idp/assertion_builder.rb
@@ -16,10 +16,11 @@ module SamlIdp
     attr_accessor :expiry
     attr_accessor :encryption_opts
     attr_accessor :session_expiry
+    attr_accessor :name_id_policy
 
     delegate :config, to: :SamlIdp
 
-    def initialize(reference_id, issuer_uri, principal, audience_uri, saml_request_id, saml_acs_url, raw_algorithm, authn_context_classref, expiry=60*60, encryption_opts=nil, session_expiry=nil)
+    def initialize(reference_id, issuer_uri, principal, audience_uri, saml_request_id, saml_acs_url, raw_algorithm, authn_context_classref, expiry=60*60, encryption_opts=nil, session_expiry=nil, name_id_policy=nil)
       self.reference_id = reference_id
       self.issuer_uri = issuer_uri
       self.principal = principal
@@ -31,6 +32,7 @@ module SamlIdp
       self.expiry = expiry
       self.encryption_opts = encryption_opts
       self.session_expiry = session_expiry.nil? ? config.session_expiry : session_expiry
+      self.name_id_policy = name_id_policy
     end
 
     def fresh
@@ -139,7 +141,7 @@ module SamlIdp
     private :name_id_getter
 
     def name_id_format
-      @name_id_format ||= NameIdFormatter.new(config.name_id.formats).chosen
+      @name_id_format ||= NameIdFormatter.new(config.name_id.formats).chosen(name_id_policy)
     end
     private :name_id_format
 

--- a/lib/saml_idp/controller.rb
+++ b/lib/saml_idp/controller.rb
@@ -30,6 +30,10 @@ module SamlIdp
         def acs_url
           nil
         end
+
+        def name_id_policy
+          nil
+        end
       end.new(nil)
     end
 
@@ -75,7 +79,8 @@ module SamlIdp
         my_authn_context_classref,
         expiry,
         encryption_opts,
-        session_expiry
+        session_expiry,
+        saml_request.name_id_policy
       ).build
     end
 

--- a/lib/saml_idp/request.rb
+++ b/lib/saml_idp/request.rb
@@ -132,6 +132,10 @@ module SamlIdp
       @_name_id ||= xpath("//saml:NameID", saml: assertion).first.try(:content)
     end
 
+    def name_id_policy
+      @_name_id_policy ||=  xpath('//samlp:NameIDPolicy').first.try(:[], 'Format')
+    end
+
     def session_index
       @_session_index ||= xpath("//samlp:SessionIndex", samlp: samlp).first.try(:content)
     end

--- a/lib/saml_idp/saml_response.rb
+++ b/lib/saml_idp/saml_response.rb
@@ -17,6 +17,7 @@ module SamlIdp
     attr_accessor :expiry
     attr_accessor :encryption_opts
     attr_accessor :session_expiry
+    attr_accessor :name_id_policy
 
     def initialize(reference_id,
           response_id,
@@ -29,7 +30,8 @@ module SamlIdp
           authn_context_classref,
           expiry=60*60,
           encryption_opts=nil,
-          session_expiry=0
+          session_expiry=0,
+          name_id_policy=nil
           )
       self.reference_id = reference_id
       self.response_id = response_id
@@ -45,6 +47,7 @@ module SamlIdp
       self.expiry = expiry
       self.encryption_opts = encryption_opts
       self.session_expiry = session_expiry
+      self.name_id_policy = name_id_policy
     end
 
     def build
@@ -76,7 +79,8 @@ module SamlIdp
         authn_context_classref,
         expiry,
         encryption_opts,
-        session_expiry
+        session_expiry,
+        name_id_policy
     end
     private :assertion_builder
   end

--- a/spec/lib/saml_idp/name_id_formatter_spec.rb
+++ b/spec/lib/saml_idp/name_id_formatter_spec.rb
@@ -10,6 +10,13 @@ module SamlIdp
         expect(subject.all).to eq ["urn:oasis:names:tc:SAML:2.0:nameid-format:emailAddress"]
       end
 
+      it 'choses first' do
+        expect(subject.chosen[:name]).to eq "urn:oasis:names:tc:SAML:2.0:nameid-format:emailAddress"
+      end
+
+      it 'choses by given format' do
+        expect(subject.chosen("urn:oasis:names:tc:SAML:2.0:nameid-format:emailAddress")[:name]).to eq "urn:oasis:names:tc:SAML:2.0:nameid-format:emailAddress"
+      end
     end
 
     describe "with hash describing versions" do
@@ -26,6 +33,12 @@ module SamlIdp
           "urn:oasis:names:tc:SAML:2.0:nameid-format:undefined",
         ]
       end
+
+      it "chooses preferred name id policy" do
+        expect(
+          subject.chosen("urn:oasis:names:tc:SAML:2.0:nameid-format:undefined")[:name]
+        ).to eq "urn:oasis:names:tc:SAML:2.0:nameid-format:undefined"
+      end
     end
 
     describe "with actual list" do
@@ -36,6 +49,12 @@ module SamlIdp
           "urn:oasis:names:tc:SAML:2.0:nameid-format:emailAddress",
           "urn:oasis:names:tc:SAML:2.0:nameid-format:undefined",
         ]
+      end
+
+      it "chooses preferred name id policy" do
+        expect(
+          subject.chosen("urn:oasis:names:tc:SAML:2.0:nameid-format:undefined")[:name]
+        ).to eq "urn:oasis:names:tc:SAML:2.0:nameid-format:undefined"
       end
     end
   end

--- a/spec/lib/saml_idp/request_spec.rb
+++ b/spec/lib/saml_idp/request_spec.rb
@@ -61,6 +61,10 @@ module SamlIdp
         expect(subject.requested_authn_context).to eq("urn:oasis:names:tc:SAML:2.0:ac:classes:Password")
       end
 
+      it 'has name id policy' do
+        expect(subject.name_id_policy).to eq("urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress")
+      end
+
       it "does not permit empty issuer" do
         raw_req = raw_authn_request.gsub('localhost:3000', '')
         authn_request = described_class.new raw_req


### PR DESCRIPTION
Until now, users can already supply multiple name formats given in the readme (persistent, transient etc) but it seems they were never used and the auth request will always just use the first name (method "chosen" by the NameIdFormatter always returned the first)

This PR fixes this by passing down the requested NameIdFormat from the request.

* If the saml client requests a specific format, then we can respond the name id with that format
* Keeping old behavior if no nameidpolicy passed down or none matching 

Use case:


e.g. if a client app is configured Omniauth-saml:

```ruby
# config/initializers/omniauth.rb
Rails.application.config.middleware.use OmniAuth::Builder do
  provider :saml, 
    issuer: '...', 
    # ....
    name_identifier_format: "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent",
```

And our IDP app is configured like this:

```ruby
SamlIdp.configure do |config|
  config.name_id.formats = {
      email_address: ->(user) { user.email },
      persistent: ->(user) { user.login_name },
    }
```

the old behavior was, the we always got the email-address field as "uid". After this PR we get the correct name id from omniauth.

```
# client-app: Omniauth Callback controller e.g. /auth/saml/callback
class OmniauthCallbackController < ApplicationController
    skip_before_action :verify_authenticity_token
    def login
       request.env['omniauth.auth']['uid'] # will be == user.login_name, not user.email
    end
end