### PR TITLE
Signed SAML response to SP

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,3 +25,16 @@ matrix:
   allow_failures:
     - rvm: ruby-head
     - gemfile: gemfiles/rails_dev.gemfile
+    - rvm: 2.4
+      gemfile: gemfiles/rails_3.2.gemfile
+    - rvm: 2.4
+      gemfile: gemfiles/rails_4.2.gemfile
+before_install:
+  # https://docs.travis-ci.com/user/languages/ruby/#bundler
+  - RUBY_VERSION=$(ruby -v | grep -o -E '[0-9]\.[0-9]' | tr -d '.')
+  # Bundler for greater than Ruby 2.3 version
+  - if [ $RUBY_VERSION -gt 23 ]; then gem update --system; fi
+  - if [ $RUBY_VERSION -gt 23 ]; then gem install bundler -v '>= 2'; fi
+  # Bundler for less than Ruby 2.3 version or Rails 4.2
+  - if [ $RUBY_VERSION -le 23 ]; then gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true; fi
+  - if [ $RUBY_VERSION -le 23 ]; then gem install bundler -v '< 2'; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,16 +46,3 @@ matrix:
   allow_failures:
     - rvm: ruby-head
     - gemfile: gemfiles/rails_dev.gemfile
-    - rvm: 2.4
-      gemfile: gemfiles/rails_3.2.gemfile
-    - rvm: 2.4
-      gemfile: gemfiles/rails_4.2.gemfile
-before_install:
-  # https://docs.travis-ci.com/user/languages/ruby/#bundler
-  - RUBY_VERSION=$(ruby -v | grep -o -E '[0-9]\.[0-9]' | tr -d '.')
-  # Bundler for greater than Ruby 2.3 version
-  - if [ $RUBY_VERSION -gt 23 ]; then gem update --system; fi
-  - if [ $RUBY_VERSION -gt 23 ]; then gem install bundler -v '>= 2'; fi
-  # Bundler for less than Ruby 2.3 version or Rails 4.2
-  - if [ $RUBY_VERSION -le 23 ]; then gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true; fi
-  - if [ $RUBY_VERSION -le 23 ]; then gem install bundler -v '< 2'; fi

--- a/README.md
+++ b/README.md
@@ -72,6 +72,22 @@ end
 
 ## Configuration
 
+#### Singed assertions and Signed Response
+
+By default SAML Assertion will be signed with an algorithm which defined to `config.algorithm`. Because SAML assertions contain secure information used for authentication such as NameID.
+
+Signing SAML Response is optional, but some security perspective SP services might require Response message itself must be signed.
+For that, you can enable it with `config.signed_message` option. [More about SAML spec](https://docs.oasis-open.org/security/saml/v2.0/saml-core-2.0-os.pdf#page=68)
+
+#### Signing algorithm
+
+Following algorithms you can set in your response signing algorithm
+:sha1 - RSA-SHA1 default value but not recommended to production environment
+Highly recommended to use one of following algorithm, suit with your computing power.
+:sha256 - RSA-SHA256
+:sha384 - RSA-SHA384
+:sha512 - RSA-SHA512
+
 Be sure to load a file like this during your app initialization:
 
 ```ruby
@@ -91,7 +107,7 @@ KEY DATA
 CERT
 
   # config.password = "secret_key_password"
-  # config.algorithm = :sha256
+  # config.algorithm = :sha256                                    # Default: sha1 only for development.
   # config.organization_name = "Your Organization"
   # config.organization_url = "http://example.com"
   # config.base_saml_location = "#{base}/saml"
@@ -101,6 +117,7 @@ CERT
   # config.attribute_service_location = "#{base}/saml/attributes"
   # config.single_service_post_location = "#{base}/saml/auth"
   # config.session_expiry = 86400                                 # Default: 0 which means never
+  # config.signed_message = true                                  # Default: false which means unsigned SAML Response
 
   # Principal (e.g. User) is passed in when you `encode_response`
   #

--- a/lib/saml_idp/controller.rb
+++ b/lib/saml_idp/controller.rb
@@ -62,6 +62,7 @@ module SamlIdp
       expiry = opts[:expiry] || 60*60
       session_expiry = opts[:session_expiry]
       encryption_opts = opts[:encryption] || nil
+      signed_message_opts = opts[:signed_message] || false
 
       SamlResponse.new(
         reference_id,
@@ -75,7 +76,8 @@ module SamlIdp
         my_authn_context_classref,
         expiry,
         encryption_opts,
-        session_expiry
+        session_expiry,
+        signed_message_opts
       ).build
     end
 

--- a/lib/saml_idp/request.rb
+++ b/lib/saml_idp/request.rb
@@ -106,6 +106,7 @@ module SamlIdp
       end
 
       if !service_provider.acceptable_response_hosts.include?(response_host)
+        log "#{service_provider.acceptable_response_hosts} compare to #{response_host}"
         log "No acceptable AssertionConsumerServiceURL, either configure them via config.service_provider.response_hosts or match to your metadata_url host"
         return false
       end

--- a/lib/saml_idp/response_builder.rb
+++ b/lib/saml_idp/response_builder.rb
@@ -1,32 +1,43 @@
 require 'builder'
+require 'saml_idp/algorithmable'
+require 'saml_idp/signable'
 module SamlIdp
   class ResponseBuilder
+    include Algorithmable
+    include Signable
     attr_accessor :response_id
     attr_accessor :issuer_uri
     attr_accessor :saml_acs_url
     attr_accessor :saml_request_id
     attr_accessor :assertion_and_signature
+    attr_accessor :raw_algorithm
 
-    def initialize(response_id, issuer_uri, saml_acs_url, saml_request_id, assertion_and_signature)
+    def initialize(response_id, issuer_uri, saml_acs_url, saml_request_id, assertion_and_signature, raw_algorithm)
       self.response_id = response_id
       self.issuer_uri = issuer_uri
       self.saml_acs_url = saml_acs_url
       self.saml_request_id = saml_request_id
       self.assertion_and_signature = assertion_and_signature
+      self.raw_algorithm = raw_algorithm
     end
 
-    def encoded
-      @encoded ||= encode
+    def encoded(signed_message: false)
+      @encoded ||= signed_message ? encode_signed_message : encode_raw_message
     end
 
     def raw
       build
     end
 
-    def encode
+    def encode_raw_message
       Base64.strict_encode64(raw)
     end
-    private :encode
+    private :encode_raw_message
+
+    def encode_signed_message
+      Base64.strict_encode64(signed)
+    end
+    private :encode_signed_message
 
     def build
       resp_options = {}
@@ -41,6 +52,7 @@ module SamlIdp
       builder = Builder::XmlMarkup.new
       builder.tag! "samlp:Response", resp_options do |response|
           response.Issuer issuer_uri, xmlns: Saml::XML::Namespaces::ASSERTION
+          sign response
           response.tag! "samlp:Status" do |status|
             status.tag! "samlp:StatusCode", Value: Saml::XML::Namespaces::Statuses::SUCCESS
           end
@@ -52,6 +64,7 @@ module SamlIdp
     def response_id_string
       "_#{response_id}"
     end
+    alias_method :reference_id, :response_id
     private :response_id_string
 
     def now_iso

--- a/lib/saml_idp/response_builder.rb
+++ b/lib/saml_idp/response_builder.rb
@@ -12,6 +12,8 @@ module SamlIdp
     attr_accessor :assertion_and_signature
     attr_accessor :raw_algorithm
 
+    alias_method :reference_id, :response_id
+
     def initialize(response_id, issuer_uri, saml_acs_url, saml_request_id, assertion_and_signature, raw_algorithm)
       self.response_id = response_id
       self.issuer_uri = issuer_uri
@@ -64,7 +66,6 @@ module SamlIdp
     def response_id_string
       "_#{response_id}"
     end
-    alias_method :reference_id, :response_id
     private :response_id_string
 
     def now_iso

--- a/lib/saml_idp/saml_response.rb
+++ b/lib/saml_idp/saml_response.rb
@@ -17,6 +17,7 @@ module SamlIdp
     attr_accessor :expiry
     attr_accessor :encryption_opts
     attr_accessor :session_expiry
+    attr_accessor :signed_message_opts
 
     def initialize(reference_id,
           response_id,
@@ -29,7 +30,8 @@ module SamlIdp
           authn_context_classref,
           expiry=60*60,
           encryption_opts=nil,
-          session_expiry=0
+          session_expiry=0,
+          signed_message_opts
           )
       self.reference_id = reference_id
       self.response_id = response_id
@@ -45,10 +47,11 @@ module SamlIdp
       self.expiry = expiry
       self.encryption_opts = encryption_opts
       self.session_expiry = session_expiry
+      self.signed_message_opts = signed_message_opts
     end
 
     def build
-      @built ||= response_builder.encoded
+      @built ||= encoded_message
     end
 
     def signed_assertion
@@ -60,8 +63,17 @@ module SamlIdp
     end
     private :signed_assertion
 
+    def encoded_message
+      if signed_message_opts
+        response_builder.encoded(signed_message: true)
+      else
+        response_builder.encoded(signed_message: false)
+      end
+    end
+    private :encoded_message
+
     def response_builder
-      ResponseBuilder.new(response_id, issuer_uri, saml_acs_url, saml_request_id, signed_assertion)
+      ResponseBuilder.new(response_id, issuer_uri, saml_acs_url, saml_request_id, signed_assertion, algorithm)
     end
     private :response_builder
 

--- a/lib/saml_idp/signable.rb
+++ b/lib/saml_idp/signable.rb
@@ -108,8 +108,7 @@ module SamlIdp
       canon_algorithm = Nokogiri::XML::XML_C14N_EXCLUSIVE_1_0
       canon_hashed_element = noko_raw.canonicalize(canon_algorithm, inclusive_namespaces)
       digest_algorithm = get_algorithm
-
-      hash                          = digest_algorithm.digest(canon_hashed_element)
+      hash = digest_algorithm.digest(canon_hashed_element)
       Base64.strict_encode64(hash).gsub(/\n/, '')
     end
     private :digest

--- a/saml_idp.gemspec
+++ b/saml_idp.gemspec
@@ -58,5 +58,5 @@ section of the README.
   s.add_development_dependency('timecop', '>= 0.8')
   s.add_development_dependency('xmlenc', '>= 0.6.4')
   s.add_development_dependency('appraisal')
+  s.add_development_dependency('byebug')
 end
-

--- a/spec/lib/saml_idp/response_builder_spec.rb
+++ b/spec/lib/saml_idp/response_builder_spec.rb
@@ -6,12 +6,14 @@ module SamlIdp
     let(:saml_acs_url) { "http://sportngin.com" }
     let(:saml_request_id) { "134" }
     let(:assertion_and_signature) { "<Assertion xmlns=\"urn:oasis:names:tc:SAML:2.0:assertion\" ID=\"_abc\" IssueInstant=\"2013-07-31T05:00:00Z\" Version=\"2.0\"><Issuer>http://sportngin.com</Issuer><signature>stuff</signature><Subject><NameID Format=\"urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress\">jon.phenow@sportngin.com</NameID><SubjectConfirmation Method=\"urn:oasis:names:tc:SAML:2.0:cm:bearer\"><SubjectConfirmationData InResponseTo=\"123\" NotOnOrAfter=\"2013-07-31T05:03:00Z\" Recipient=\"http://saml.acs.url\"/></SubjectConfirmation></Subject><Conditions NotBefore=\"2013-07-31T04:59:55Z\" NotOnOrAfter=\"2013-07-31T06:00:00Z\"><AudienceRestriction><Audience>http://example.com</Audience></AudienceRestriction></Conditions><AttributeStatement><Attribute Name=\"http://schemas.xmlsoap.org/ws/2005/05/identity/claims/emailaddress\"><AttributeValue>jon.phenow@sportngin.com</AttributeValue></Attribute></AttributeStatement><AuthnStatment AuthnInstant=\"2013-07-31T05:00:00Z\" SessionIndex=\"_abc\"><AuthnContext><AuthnContextClassRef>urn:federation:authentication:windows</AuthnContextClassRef></AuthnContext></AuthnStatment></Assertion>" }
+    let(:algorithm) { :sha256 }
     subject { described_class.new(
       response_id,
       issuer_uri,
       saml_acs_url,
       saml_request_id,
-      assertion_and_signature
+      assertion_and_signature,
+      algorithm
     ) }
 
     before do


### PR DESCRIPTION
This pull request contains 2 changes.
1. Signed response
Currently, gem only signing Assertion, but there are several patterns can be exists ([here is examples](https://www.samltool.com/generic_sso_res.php)) one of them is signed response.
2. Travis build fixes for Ruby and Rails version dependency issue