### PR TITLE
Configurable SLO/SSO Metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,11 +93,17 @@ CERT
   # config.organization_url = "http://example.com"
   # config.base_saml_location = "#{base}/saml"
   # config.reference_id_generator                                 # Default: -> { UUID.generate }
+  # config.session_expiry = 86400                                 # Default: 0 which means never
+
+
+  # Uncomment each protocol/binding that should be returned by the metadata endpoint
+  # For example, if SLO is not implemented, but both redirect & post bindings for SSO is,
+  # then `config.single_service_post_location` and `config.single_service_redirect_location`
+  # should be set
   # config.single_logout_service_post_location = "#{base}/saml/logout"
   # config.single_logout_service_redirect_location = "#{base}/saml/logout"
-  # config.attribute_service_location = "#{base}/saml/attributes"
   # config.single_service_post_location = "#{base}/saml/auth"
-  # config.session_expiry = 86400                                 # Default: 0 which means never
+  # config.single_service_redirect_location = "#{base}/saml/auth"
 
   # Principal (e.g. User) is passed in when you `encode_response`
   #

--- a/lib/saml_idp/configurator.rb
+++ b/lib/saml_idp/configurator.rb
@@ -11,8 +11,8 @@ module SamlIdp
     attr_accessor :base_saml_location
     attr_accessor :entity_id
     attr_accessor :reference_id_generator
-    attr_accessor :attribute_service_location
     attr_accessor :single_service_post_location
+    attr_accessor :single_service_redirect_location
     attr_accessor :single_logout_service_post_location
     attr_accessor :single_logout_service_redirect_location
     attr_accessor :attributes

--- a/lib/saml_idp/metadata_builder.rb
+++ b/lib/saml_idp/metadata_builder.rb
@@ -24,24 +24,29 @@ module SamlIdp
 
             entity.IDPSSODescriptor protocolSupportEnumeration: protocol_enumeration do |descriptor|
               build_key_descriptor descriptor
-              descriptor.SingleLogoutService Binding: "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
-                Location: single_logout_service_post_location
-              descriptor.SingleLogoutService Binding: "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
-                Location: single_logout_service_redirect_location
-              build_name_id_formats descriptor
-              descriptor.SingleSignOnService Binding: "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
-                Location: single_service_post_location
-              build_attribute descriptor
-            end
+              if single_logout_service_post_location
+                descriptor.SingleLogoutService Binding: "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
+                  Location: single_logout_service_post_location
+              end
 
-            entity.AttributeAuthorityDescriptor protocolSupportEnumeration: protocol_enumeration do |authority_descriptor|
-              build_key_descriptor authority_descriptor
-              build_organization authority_descriptor
-              build_contact authority_descriptor
-              authority_descriptor.AttributeService Binding: "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
-                Location: attribute_service_location
-              build_name_id_formats authority_descriptor
-              build_attribute authority_descriptor
+              if single_logout_service_redirect_location
+                descriptor.SingleLogoutService Binding: "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
+                  Location: single_logout_service_redirect_location
+              end
+
+              build_name_id_formats descriptor
+
+              if single_service_post_location
+                descriptor.SingleSignOnService Binding: "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST",
+                  Location: single_service_post_location
+              end
+
+              if single_service_redirect_location
+                descriptor.SingleSignOnService Binding: "urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect",
+                  Location: single_service_redirect_location
+              end
+
+              build_attribute descriptor
             end
 
             build_organization entity
@@ -149,8 +154,8 @@ module SamlIdp
       support_email
       organization_name
       organization_url
-      attribute_service_location
       single_service_post_location
+      single_service_redirect_location
       single_logout_service_post_location
       single_logout_service_redirect_location
       technical_contact

--- a/spec/lib/saml_idp/configurator_spec.rb
+++ b/spec/lib/saml_idp/configurator_spec.rb
@@ -8,8 +8,8 @@ module SamlIdp
     it { should respond_to :organization_url }
     it { should respond_to :base_saml_location }
     it { should respond_to :reference_id_generator }
-    it { should respond_to :attribute_service_location }
     it { should respond_to :single_service_post_location }
+    it { should respond_to :single_service_redirect_location }
     it { should respond_to :single_logout_service_post_location }
     it { should respond_to :single_logout_service_redirect_location }
     it { should respond_to :name_id }

--- a/spec/lib/saml_idp/metadata_builder_spec.rb
+++ b/spec/lib/saml_idp/metadata_builder_spec.rb
@@ -9,11 +9,6 @@ module SamlIdp
       expect(Saml::XML::Document.parse(subject.signed).valid_signature?(Default::FINGERPRINT)).to be_truthy
     end
 
-    it "includes logout element" do
-      subject.configurator.single_logout_service_post_location = 'https://example.com/saml/logout'
-      expect(subject.fresh).to match('<SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://example.com/saml/logout"/>')
-    end
-
     context "technical contact" do
       before do
         subject.configurator.technical_contact.company       = nil
@@ -44,9 +39,41 @@ module SamlIdp
 
     end
 
-    it "includes logout element as HTTP Redirect" do
-      subject.configurator.single_logout_service_redirect_location = 'https://example.com/saml/logout'
-      expect(subject.fresh).to match('<SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://example.com/saml/logout"/>')
+    context "SLO bindings" do
+      it "post binding" do
+        subject.configurator.single_logout_service_post_location = 'https://example.com/saml/logout'
+        expect(subject.fresh).to match('<SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://example.com/saml/logout"/>')
+      end
+
+      it "redirect binding" do
+        subject.configurator.single_logout_service_redirect_location = 'https://example.com/saml/logout'
+        expect(subject.fresh).to match('<SingleLogoutService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://example.com/saml/logout"/>')
+      end
+
+      it "no bindings" do
+        subject.configurator.single_logout_service_post_location     = nil
+        subject.configurator.single_logout_service_redirect_location = nil
+        expect(subject.fresh).not_to match('<SingleLogoutService')
+      end
     end
+
+    context "SSO bindings" do
+      it "post binding" do
+        subject.configurator.single_service_post_location = 'https://example.com/saml/auth'
+        expect(subject.fresh).to match('<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST" Location="https://example.com/saml/auth"/>')
+      end
+
+      it "redirect binding" do
+        subject.configurator.single_service_redirect_location = 'https://example.com/saml/auth'
+        expect(subject.fresh).to match('<SingleSignOnService Binding="urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect" Location="https://example.com/saml/auth"/>')
+      end
+
+      it "no bindings" do
+        subject.configurator.single_service_post_location     = nil
+        subject.configurator.single_service_redirect_location = nil
+        expect(subject.fresh).not_to match('<SingleSignOnService')
+      end
+    end
+
   end
 end


### PR DESCRIPTION
This fixes #90 

Technically this is a duplicate of #89 and #78 however this PR checks to see if a given service/binding has a defined location in the config (e.g. `single_logout_service_post_location`) before adding it to the metadata.

I also removed references to the attribute service, since that functionality isn't implemented at all in this project.