### PR TITLE
fix missing ns prefix for algorithm in signature verification code

### DIFF
--- a/lib/saml_idp/xml_security.rb
+++ b/lib/saml_idp/xml_security.rb
@@ -108,7 +108,7 @@ module SamlIdp
           canon_algorithm               = canon_algorithm REXML::XPath.first(ref, '//ds:CanonicalizationMethod', 'ds' => DSIG)
           canon_hashed_element          = hashed_element.canonicalize(canon_algorithm, inclusive_namespaces)
 
-          digest_algorithm              = algorithm(REXML::XPath.first(ref, "//ds:DigestMethod"))
+          digest_algorithm              = algorithm(REXML::XPath.first(ref, "//ds:DigestMethod", {'ds' => DSIG}))
 
           hash                          = digest_algorithm.digest(canon_hashed_element)
           digest_value                  = Base64.decode64(REXML::XPath.first(ref, "//ds:DigestValue", {"ds"=>DSIG}).text)


### PR DESCRIPTION
fixes signature verification for xml without explicit ds prefix and
custom digest algorithm.

This fixes verification of mod_auth_mellon signed authentication requests using anything else than sha1. This was (most probably) unearthed by an update to php-xml 7.3.9.