### PR TITLE
update docs for config.name_id.format

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ CERT
 
   # Principal (e.g. User) is passed in when you `encode_response`
   #
-  # config.name_id.formats # =>
+  # config.name_id.formats =
   #   {                         # All 2.0
   #     email_address: -> (principal) { principal.email_address },
   #     transient: -> (principal) { principal.id },


### PR DESCRIPTION
Hi, first of all - thanks REALLY a lot for this awesome gem!

Here's a tiny fix on the document so as to support easier start for the gem users.

I found the configuration samples on `config.name_id.formats` slightly misleading, and am guessing this change will prevent issues like (https://github.com/saml-idp/saml_idp/issues/79).

Hope this helps!