### PR TITLE
remove ds:KeyName when building encryption template

### DIFF
--- a/lib/saml_idp/encryptor.rb
+++ b/lib/saml_idp/encryptor.rb
@@ -61,7 +61,6 @@ module SamlIdp
           key_info.EncryptedKey Id: 'EK', xmlns: 'http://www.w3.org/2001/04/xmlenc#' do |enc_key|
             enc_key.EncryptionMethod Algorithm: key_transport_ns
             enc_key.tag! 'ds:KeyInfo', 'xmlns:ds' => 'http://www.w3.org/2000/09/xmldsig#' do |key_info2|
-              key_info2.tag! 'ds:KeyName'
               key_info2.tag! 'ds:X509Data' do |x509_data|
                 x509_data.tag! 'ds:X509Certificate' do |x509_cert|
                   x509_cert << cert.to_s.gsub(/-+(BEGIN|END) CERTIFICATE-+/, '') 


### PR DESCRIPTION
We ran into an issue with this keyname and the SP was refusing our IdP.
we just started working when we remove this line.

maybe we have configured something wrong?

should this be optional?
I wonder if removing it could affect others?

but this change helped us move forward.

thank you for reviewing