### PR TITLE
Add deprecation warning for Rails < 5.2

### DIFF
--- a/lib/saml_idp/engine.rb
+++ b/lib/saml_idp/engine.rb
@@ -2,4 +2,12 @@
 module SamlIdp
   class Engine < Rails::Engine
   end
+
+  def self.warn_for_deprecated_rails
+    if defined?(Rails) && Rails.version.split('.').map(&:to_i)[0..1].join.to_i < 52
+      warn "You are running a deprecated version of Rails, saml_idp might remove support for older rails (< 5.2) in upcoming release."
+    end
+  end
 end
+
+SamlIdp.warn_for_deprecated_rails

--- a/saml_idp.gemspec
+++ b/saml_idp.gemspec
@@ -26,6 +26,10 @@ Gem::Specification.new do |s|
     'documentation_uri' => "http://rdoc.info/gems/saml_idp/#{SamlIdp::VERSION}"
   }
 
+  DEPRECATED_RAILS = if defined?(Rails) && Rails.version.split('.').map(&:to_i)[0..1].join.to_i < 52
+    "You are running a deprecated version of Rails, saml_idp might remove support for older rails in upcoming release."
+  end
+
   s.post_install_message = <<-INST
 If you're just recently updating saml_idp - please be aware we've changed the default
 certificate. See the PR and a description of why we've done this here:
@@ -36,8 +40,6 @@ If you just need to see the certificate `bundle open saml_idp` and go to
 
 Similarly, please see the README about certificates - you should avoid using the
 defaults in a Production environment. Post any issues you to github.
-
-** New in Version 0.3.0 **
 
 Encrypted Assertions require the xmlenc gem. See the example in the Controller
 section of the README.


### PR DESCRIPTION
What do you think of officially deprecating Rails `< 5.2` in the next release?
we start by adding a Warning for 0.12.0
let that go for a while.
and then modify the gemspec for 0.13.0 or update the numbering? 0.20.0 ? 1.0 ? 
