### PR TITLE
Add helper to create fingerprint from cert

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,15 @@ The fingerprint to use, if you use the default X.509 certificate of this gem, is
 9E:65:2E:03:06:8D:80:F2:86:C7:6C:77:A1:D9:14:97:0A:4D:F4:4D
 ```
 
+# Fingerprint
+
+The gem provides an helper to generate a fingerprint for a X.509 certificate.
+The second parameter is optional and default to your configuration `SamlIdp.config.algorithm`
+
+```ruby
+Fingerprint.certificate_digest(x509_cert, :sha512)
+```
+
 # Service Providers
 
 To act as a Service Provider which generates SAML Requests and can react to SAML Responses use the

--- a/lib/saml_idp.rb
+++ b/lib/saml_idp.rb
@@ -8,6 +8,7 @@ module SamlIdp
   require 'saml_idp/default'
   require 'saml_idp/metadata_builder'
   require 'saml_idp/version'
+  require 'saml_idp/fingerprint'
   require 'saml_idp/engine' if defined?(::Rails) && Rails::VERSION::MAJOR > 2
 
   def self.config

--- a/lib/saml_idp/fingerprint.rb
+++ b/lib/saml_idp/fingerprint.rb
@@ -1,0 +1,19 @@
+module SamlIdp
+  module Fingerprint
+    def self.certificate_digest(cert, sha_size = nil)
+      sha_size ||= SamlIdp.config.algorithm
+      digest_sha_class(sha_size).hexdigest(OpenSSL::X509::Certificate.new(cert).to_der).scan(/../).join(':')
+    end
+
+    def self.digest_sha_class(sha_size)
+      case sha_size
+      when :sha256
+        Digest::SHA256
+      when :sha512
+        Digest::SHA512
+      else
+        raise ArgumentError, "Unsupported sha size parameter: #{sha_size}"
+      end
+    end
+  end
+end

--- a/spec/lib/saml_idp/fingerprint_spec.rb
+++ b/spec/lib/saml_idp/fingerprint_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+module SamlIdp
+  describe Fingerprint do
+    describe "certificate_digest" do
+      let(:cert) { sp_x509_cert }
+      let(:fingerprint) { "a2:cb:f6:6b:bc:2a:33:b9:4f:f3:c3:7e:26:a4:21:cd:41:83:ef:26:88:fa:ba:71:37:40:07:3e:d5:76:04:b7" }
+
+      it "returns the fingerprint string" do
+        expect(Fingerprint.certificate_digest(cert, :sha256)).to eq(fingerprint)
+      end
+    end
+  end
+end

--- a/spec/support/saml_request_macros.rb
+++ b/spec/support/saml_request_macros.rb
@@ -82,7 +82,7 @@ module SamlRequestMacros
           response_hosts: [URI(saml_acs_url).host],
           acs_url: saml_acs_url,
           cert: sp_x509_cert,
-          fingerprint: Digest::SHA256.hexdigest(OpenSSL::X509::Certificate.new(sp_x509_cert).to_der).scan(/../).join(':')
+          fingerprint: SamlIdp::Fingerprint.certificate_digest(sp_x509_cert)
         }
       }
     end


### PR DESCRIPTION
extract existing code for integrator to be able to reuse

I am using this bit of code in my project to find a fingerprint
and I figured the best place to keep it, is within the gem itself.

I can rename the module

let me know

thanks

