### PR TITLE
bump minimum versions

### DIFF
--- a/saml_idp.gemspec
+++ b/saml_idp.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.description = 'SAML IdP (Identity Provider) Library for Ruby'
   s.date = Time.now.utc.strftime("%Y-%m-%d")
   s.files = Dir['app/**/*', 'lib/**/*', 'LICENSE', 'README.md', 'Gemfile', 'saml_idp.gemspec']
-  s.required_ruby_version = '>= 2.2'
+  s.required_ruby_version = '>= 2.5'
   s.license = 'MIT'
   s.test_files = `git ls-files -- {test,spec,features}/*`.split("\n")
   s.executables = `git ls-files -- bin/*`.split("\n").map{ |f| File.basename(f) }
@@ -43,7 +43,7 @@ Encrypted Assertions require the xmlenc gem. See the example in the Controller
 section of the README.
   INST
 
-  s.add_dependency('activesupport', '>= 3.2')
+  s.add_dependency('activesupport', '>= 5.2')
   s.add_dependency('builder', '>= 3.0')
   s.add_dependency('nokogiri', '>= 1.6.2')
 
@@ -51,8 +51,8 @@ section of the README.
   s.add_development_dependency('simplecov')
   s.add_development_dependency('rspec', '>= 3.7.0')
   s.add_development_dependency('ruby-saml', '>= 1.7.2')
-  s.add_development_dependency('rails', '>= 3.2')
-  s.add_development_dependency('activeresource', '>= 3.2')
+  s.add_development_dependency('rails', '>= 5.2')
+  s.add_development_dependency('activeresource', '>= 5.2')
   s.add_development_dependency('capybara', '>= 2.16')
   s.add_development_dependency('timecop', '>= 0.8')
   s.add_development_dependency('xmlenc', '>= 0.6.4')


### PR DESCRIPTION
since this other commit, it makes sense to bump the minimum version of ruby+rails

https://github.com/saml-idp/saml_idp/commit/26220a0c5eb7b3c833c88a3e3d13c480565ec2b4