### PR TITLE
Change logout action to destroy

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Add to your `routes.rb` file, for example:
 get '/saml/auth' => 'saml_idp#new'
 get '/saml/metadata' => 'saml_idp#show'
 post '/saml/auth' => 'saml_idp#create'
-match '/saml/logout' => 'saml_idp#logout', via: [:get, :post, :delete]
+match '/saml/logout' => 'saml_idp#destroy', via: [:get, :post, :delete]
 ```
 
 Create a controller that looks like this, customize to your own situation:

--- a/app/controllers/saml_idp/idp_controller.rb
+++ b/app/controllers/saml_idp/idp_controller.rb
@@ -8,9 +8,9 @@ module SamlIdp
     protect_from_forgery
 
     if Rails::VERSION::MAJOR >= 4
-      before_action :validate_saml_request, only: [:new, :create, :logout]
+      before_action :validate_saml_request, only: [:new, :create, :destroy]
     else
-      before_filter :validate_saml_request, only: [:new, :create, :logout]
+      before_filter :validate_saml_request, only: [:new, :create, :destroy]
     end
 
     def new
@@ -35,7 +35,7 @@ module SamlIdp
       render :template => "saml_idp/idp/new"
     end
 
-    def logout
+    def destroy
       idp_logout
       @saml_response = idp_make_saml_response(nil)
       render :template => "saml_idp/idp/saml_post", :layout => false


### PR DESCRIPTION
The `logout` controller action is colliding with other libraries that use the same method, such as sorcery. Changing it to `destroy` seems more appropriate.