### PR TITLE
rexml are default gems to bundled gem for ruby 2.8 (3.0)

### DIFF
--- a/saml_idp.gemspec
+++ b/saml_idp.gemspec
@@ -46,6 +46,7 @@ section of the README.
   s.add_dependency('activesupport', '>= 3.2')
   s.add_dependency('builder', '>= 3.0')
   s.add_dependency('nokogiri', '>= 1.6.2')
+  s.add_dependency('rexml')
 
   s.add_development_dependency('rake')
   s.add_development_dependency('simplecov')


### PR DESCRIPTION
- https://bugs.ruby-lang.org/issues/16485

add dependency.