### PR TITLE
Support Github document

### DIFF
--- a/Appraisals
+++ b/Appraisals
@@ -10,5 +10,5 @@ end
 
 appraise 'rails-dev' do
   gem 'rails', :github => 'rails/rails', :branch => 'main'
-  gem 'activeresource', :github => 'rails/activeresource', :branch => 'master'
+  gem 'activeresource', :github => 'rails/activeresource', :branch => 'main'
 end

--- a/gemfiles/rails_dev.gemfile
+++ b/gemfiles/rails_dev.gemfile
@@ -3,6 +3,6 @@
 source "https://rubygems.org"
 
 gem "rails", github: "rails/rails", branch: "main"
-gem "activeresource", github: "rails/activeresource", branch: "master"
+gem "activeresource", github: "rails/activeresource", branch: "main"
 
 gemspec path: "../"


### PR DESCRIPTION
Another day I enabled GitHub document but it automatically affected our git hub action which was an unexpected result. Let me add the docs folder to support the public documentation site.