### PR TITLE
Added `SamlIdp::Fingerprint` instead `Fingerprint`

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ The gem provides an helper to generate a fingerprint for a X.509 certificate.
 The second parameter is optional and default to your configuration `SamlIdp.config.algorithm`
 
 ```ruby
-  Fingerprint.certificate_digest(x509_cert, :sha512)
+  SamlIdp::Fingerprint.certificate_digest(x509_cert, :sha512)
 ```
 
 ## Service Providers


### PR DESCRIPTION
When we run `Fingerprint.certificate_digest(x509_cert, :sha512)` on console it gives error as `undefined local variable or method `x509_cert' for main:Object (NameError)`. Since `Fingerprint` class has been defined inside `SamlIdp`. By making this edit users can easily copy from ReadME  