### PR TITLE
Added options to switch IdP configurations such as x509cert, secret key and password on the fly

### DIFF
--- a/lib/saml_idp/assertion_builder.rb
+++ b/lib/saml_idp/assertion_builder.rb
@@ -18,6 +18,9 @@ module SamlIdp
     attr_accessor :session_expiry
     attr_accessor :name_id_formats_opts
     attr_accessor :asserted_attributes_opts
+    attr_accessor :x509_certificate
+    attr_accessor :secret_key
+    attr_accessor :password
 
     delegate :config, to: :SamlIdp
 
@@ -34,7 +37,10 @@ module SamlIdp
         encryption_opts=nil,
         session_expiry=nil,
         name_id_formats_opts = nil,
-        asserted_attributes_opts = nil
+        asserted_attributes_opts = nil,
+        x509_certificate = nil,
+        secret_key = nil,
+        password = nil
     )
       self.reference_id = reference_id
       self.issuer_uri = issuer_uri
@@ -49,6 +55,9 @@ module SamlIdp
       self.session_expiry = session_expiry.nil? ? config.session_expiry : session_expiry
       self.name_id_formats_opts = name_id_formats_opts
       self.asserted_attributes_opts = asserted_attributes_opts
+      self.x509_certificate = x509_certificate
+      self.secret_key = secret_key
+      self.password = password
     end
 
     def fresh

--- a/lib/saml_idp/controller.rb
+++ b/lib/saml_idp/controller.rb
@@ -63,6 +63,9 @@ module SamlIdp
       signed_message_opts = opts[:signed_message] || false
       name_id_formats_opts = opts[:name_id_formats] || nil
       asserted_attributes_opts = opts[:attributes] || nil
+      x509_certificate_opts = opts[:x509_certificate] || nil
+      secret_key_opts = opts[:secret_key] || nil
+      password_opts = opts[:password] || nil
 
       SamlResponse.new(
         reference_id,
@@ -79,7 +82,10 @@ module SamlIdp
         session_expiry,
         signed_message_opts,
         name_id_formats_opts,
-        asserted_attributes_opts
+        asserted_attributes_opts,
+        x509_certificate_opts,
+        secret_key_opts,
+        password_opts
       ).build
     end
 
@@ -89,7 +95,10 @@ module SamlIdp
         (opts[:issuer_uri] || issuer_uri),
         saml_logout_url,
         saml_request_id,
-        (opts[:algorithm] || algorithm || default_algorithm)
+        (opts[:algorithm] || algorithm || default_algorithm),
+        opts[:x509_certificate] || nil,
+        opts[:secret_key] || nil,
+        opts[:password] || nil
       ).signed
     end
 

--- a/lib/saml_idp/logout_builder.rb
+++ b/lib/saml_idp/logout_builder.rb
@@ -7,12 +7,26 @@ module SamlIdp
     attr_accessor :issuer_uri
     attr_accessor :saml_slo_url
     attr_accessor :algorithm
+    attr_accessor :x509_certificate
+    attr_accessor :secret_key
+    attr_accessor :password
 
-    def initialize(response_id, issuer_uri, saml_slo_url, algorithm)
+    def initialize(
+      response_id,
+      issuer_uri,
+      saml_slo_url,
+      algorithm,
+      x509_certificate = nil,
+      secret_key = nil,
+      password = nil
+    )
       self.response_id = response_id
       self.issuer_uri = issuer_uri
       self.saml_slo_url = saml_slo_url
       self.algorithm = algorithm
+      self.x509_certificate = x509_certificate
+      self.secret_key = secret_key
+      self.password = password
     end
 
     # this is an abstract base class.

--- a/lib/saml_idp/logout_request_builder.rb
+++ b/lib/saml_idp/logout_request_builder.rb
@@ -3,8 +3,17 @@ module SamlIdp
   class LogoutRequestBuilder < LogoutBuilder
     attr_accessor :name_id
 
-    def initialize(response_id, issuer_uri, saml_slo_url, name_id, algorithm)
-      super(response_id, issuer_uri, saml_slo_url, algorithm)
+    def initialize(
+      response_id,
+      issuer_uri,
+      saml_slo_url,
+      name_id,
+      algorithm,
+      x509_certificate = nil,
+      secret_key = nil,
+      password = nil
+    )
+      super(response_id, issuer_uri, saml_slo_url, algorithm, x509_certificate, secret_key, password)
       self.name_id = name_id
     end
 

--- a/lib/saml_idp/logout_response_builder.rb
+++ b/lib/saml_idp/logout_response_builder.rb
@@ -3,8 +3,17 @@ module SamlIdp
   class LogoutResponseBuilder < LogoutBuilder
     attr_accessor :saml_request_id
 
-    def initialize(response_id, issuer_uri, saml_slo_url, saml_request_id, algorithm)
-      super(response_id, issuer_uri, saml_slo_url, algorithm)
+    def initialize(
+      response_id,
+      issuer_uri,
+      saml_slo_url,
+      saml_request_id,
+      algorithm,
+      x509_certificate = nil,
+      secret_key = nil,
+      password = nil
+    )
+      super(response_id, issuer_uri, saml_slo_url, algorithm, x509_certificate, secret_key, password)
       self.saml_request_id = saml_request_id
     end
 

--- a/lib/saml_idp/metadata_builder.rb
+++ b/lib/saml_idp/metadata_builder.rb
@@ -7,9 +7,19 @@ module SamlIdp
     include Algorithmable
     include Signable
     attr_accessor :configurator
+    attr_accessor :x509_certificate
+    attr_accessor :secret_key
+    attr_accessor :password
 
     def initialize(configurator = SamlIdp.config)
       self.configurator = configurator
+    end
+
+    def customized(x509_certificate = nil, secret_key = nil, password = nil)
+      self.x509_certificate = x509_certificate
+      self.secret_key = secret_key
+      self.password = password
+      self
     end
 
     def fresh
@@ -58,7 +68,7 @@ module SamlIdp
       el.KeyDescriptor use: "signing" do |key_descriptor|
         key_descriptor.KeyInfo xmlns: Saml::XML::Namespaces::SIGNATURE do |key_info|
           key_info.X509Data do |x509|
-            x509.X509Certificate x509_certificate
+            x509.X509Certificate get_x509_certificate
           end
         end
       end
@@ -150,14 +160,6 @@ module SamlIdp
       configurator.algorithm
     end
     private :raw_algorithm
-
-    def x509_certificate
-      SamlIdp.config.x509_certificate
-      .to_s
-      .gsub(/-----BEGIN CERTIFICATE-----/,"")
-      .gsub(/-----END CERTIFICATE-----/,"")
-      .gsub(/\n/, "")
-    end
 
     %w[
       support_email

--- a/lib/saml_idp/response_builder.rb
+++ b/lib/saml_idp/response_builder.rb
@@ -11,16 +11,32 @@ module SamlIdp
     attr_accessor :saml_request_id
     attr_accessor :assertion_and_signature
     attr_accessor :raw_algorithm
+    attr_accessor :x509_certificate
+    attr_accessor :secret_key
+    attr_accessor :password
 
     alias_method :reference_id, :response_id
 
-    def initialize(response_id, issuer_uri, saml_acs_url, saml_request_id, assertion_and_signature, raw_algorithm)
+    def initialize(
+      response_id,
+      issuer_uri,
+      saml_acs_url,
+      saml_request_id,
+      assertion_and_signature,
+      raw_algorithm,
+      x509_certificate = nil,
+      secret_key = nil,
+      password = nil
+    )
       self.response_id = response_id
       self.issuer_uri = issuer_uri
       self.saml_acs_url = saml_acs_url
       self.saml_request_id = saml_request_id
       self.assertion_and_signature = assertion_and_signature
       self.raw_algorithm = raw_algorithm
+      self.x509_certificate = x509_certificate
+      self.secret_key = secret_key
+      self.password = password
     end
 
     def encoded(signed_message: false)

--- a/lib/saml_idp/saml_response.rb
+++ b/lib/saml_idp/saml_response.rb
@@ -11,8 +11,6 @@ module SamlIdp
     attr_accessor :saml_request_id
     attr_accessor :saml_acs_url
     attr_accessor :algorithm
-    attr_accessor :secret_key
-    attr_accessor :x509_certificate
     attr_accessor :authn_context_classref
     attr_accessor :expiry
     attr_accessor :encryption_opts
@@ -20,6 +18,9 @@ module SamlIdp
     attr_accessor :signed_message_opts
     attr_accessor :name_id_formats_opts
     attr_accessor :asserted_attributes_opts
+    attr_accessor :x509_certificate
+    attr_accessor :secret_key
+    attr_accessor :password
 
     def initialize(
         reference_id,
@@ -36,7 +37,10 @@ module SamlIdp
         session_expiry=0,
         signed_message_opts=false,
         name_id_formats_opts = nil,
-        asserted_attributes_opts = nil
+        asserted_attributes_opts = nil,
+        x509_certificate_opts = nil,
+        secret_key_opts = nil,
+        password_opts = nil
     )
       self.reference_id = reference_id
       self.response_id = response_id
@@ -47,7 +51,6 @@ module SamlIdp
       self.saml_acs_url = saml_acs_url
       self.algorithm = algorithm
       self.secret_key = secret_key
-      self.x509_certificate = x509_certificate
       self.authn_context_classref = authn_context_classref
       self.expiry = expiry
       self.encryption_opts = encryption_opts
@@ -55,6 +58,9 @@ module SamlIdp
       self.signed_message_opts = signed_message_opts
       self.name_id_formats_opts = name_id_formats_opts
       self.asserted_attributes_opts = asserted_attributes_opts
+      self.x509_certificate = x509_certificate_opts
+      self.secret_key = secret_key_opts
+      self.password = password_opts
     end
 
     def build
@@ -97,7 +103,10 @@ module SamlIdp
         encryption_opts,
         session_expiry,
         name_id_formats_opts,
-        asserted_attributes_opts
+        asserted_attributes_opts,
+        x509_certificate,
+        secret_key,
+        password
     end
     private :assertion_builder
   end

--- a/lib/saml_idp/saml_response.rb
+++ b/lib/saml_idp/saml_response.rb
@@ -86,7 +86,17 @@ module SamlIdp
     private :encoded_message
 
     def response_builder
-      ResponseBuilder.new(response_id, issuer_uri, saml_acs_url, saml_request_id, signed_assertion, algorithm)
+      ResponseBuilder.new(
+        response_id,
+        issuer_uri,
+        saml_acs_url,
+        saml_request_id,
+        signed_assertion,
+        algorithm,
+        x509_certificate,
+        secret_key,
+        password
+      )
     end
     private :response_builder
 

--- a/lib/saml_idp/signature_builder.rb
+++ b/lib/saml_idp/signature_builder.rb
@@ -2,9 +2,11 @@ require 'builder'
 module SamlIdp
   class SignatureBuilder
     attr_accessor :signed_info_builder
+    attr_accessor :x509_certificate
 
-    def initialize(signed_info_builder)
+    def initialize(signed_info_builder, x509_certificate)
       self.signed_info_builder = signed_info_builder
+      self.x509_certificate = x509_certificate
     end
 
     def raw
@@ -19,15 +21,6 @@ module SamlIdp
         end
       end
     end
-
-    def x509_certificate
-      SamlIdp.config.x509_certificate
-      .to_s
-      .gsub(/-----BEGIN CERTIFICATE-----/,"")
-      .gsub(/-----END CERTIFICATE-----/,"")
-      .gsub(/\n/, "")
-    end
-    private :x509_certificate
 
     def signed_info
       signed_info_builder.raw

--- a/lib/saml_idp/signed_info_builder.rb
+++ b/lib/saml_idp/signed_info_builder.rb
@@ -22,11 +22,15 @@ module SamlIdp
     attr_accessor :reference_id
     attr_accessor :digest_value
     attr_accessor :raw_algorithm
+    attr_accessor :secret_key
+    attr_accessor :password
 
-    def initialize(reference_id, digest_value, raw_algorithm)
+    def initialize(reference_id, digest_value, raw_algorithm, secret_key, password)
       self.reference_id = reference_id
       self.digest_value = digest_value
       self.raw_algorithm = raw_algorithm
+      self.secret_key = secret_key
+      self.password = password
     end
 
     def raw
@@ -63,16 +67,6 @@ module SamlIdp
       algorithm_name.to_s.downcase
     end
     private :clean_algorithm_name
-
-    def secret_key
-      SamlIdp.config.secret_key
-    end
-    private :secret_key
-
-    def password
-      SamlIdp.config.password
-    end
-    private :password
 
     def encoded
       key = OpenSSL::PKey::RSA.new(secret_key, password)

--- a/spec/lib/saml_idp/saml_response_spec.rb
+++ b/spec/lib/saml_idp/saml_response_spec.rb
@@ -10,7 +10,7 @@ module SamlIdp
     let(:saml_acs_url) { "localhost/acs" }
     let(:algorithm) { :sha1 }
     let(:secret_key) { Default::SECRET_KEY }
-    let(:x509_certificate) { Default::X509_CERTIFICATE }
+    let(:default_x509_certificate) { Default::X509_CERTIFICATE }
     let(:xauthn) { Default::X509_CERTIFICATE }
     let(:authn_context_classref) {
       Saml::XML::Namespaces::AuthnContext::ClassRef::PASSWORD

--- a/spec/lib/saml_idp/signable_spec.rb
+++ b/spec/lib/saml_idp/signable_spec.rb
@@ -21,6 +21,18 @@ class MockSignable
   def algorithm
     OpenSSL::Digest::SHA1
   end
+
+  def x509_certificate
+    SamlIdp::Default::X509_CERTIFICATE
+  end
+
+  def secret_key
+    SamlIdp::Default::SECRET_KEY
+  end
+
+  def password
+    "password"
+  end
 end
 
 module SamlIdp

--- a/spec/lib/saml_idp/signature_builder_spec.rb
+++ b/spec/lib/saml_idp/signature_builder_spec.rb
@@ -4,8 +4,10 @@ module SamlIdp
     let(:signed) { "jvEbD/rsiPKmoXy7Lhm+FGn88NPGlap4EcPZ2fvjBnk03YESs87FXAIiZZEzN5xq4sBZksUmZe2bV3rrr9sxQNgQawmrrvr66ot7cJiv0ETFArr6kQIZaR5g/V0M4ydxvrfefp6cQVI0hXvmxi830pq0tISiO4J7tyBNX/kvhZk=" }
     let(:raw_info) { "<ds:SignedInfo xmlns:ds=\"http://www.w3.org/2000/09/xmldsig#\"><ds:CanonicalizationMethod Algorithm=\"http://www.w3.org/2001/10/xml-exc-c14n#\"/><ds:SignatureMethod Algorithm=\"http://www.w3.org/2000/09/xmldsig#rsa-sha256\"/><ds:Reference URI=\"#_abc\"><ds:Transforms><ds:Transform Algorithm=\"http://www.w3.org/2000/09/xmldsig#enveloped-signature\"/><ds:Transform Algorithm=\"http://www.w3.org/2001/10/xml-exc-c14n#\"/></ds:Transforms><ds:DigestMethod Algorithm=\"http://www.w3.org/2000/09/xmldsig#sha256\"/><ds:DigestValue>em8csGAWynywpe8S4nN64o56/4DosXi2XWMY6RJ6YfA=</ds:DigestValue></ds:Reference></ds:SignedInfo>" }
     let(:signed_info) { double raw: raw_info, signed: signed }
+    let(:x509_certificate) { "MIIDqzCCAxSgAwIBAgIBATANBgkqhkiG9w0BAQsFADCBhjELMAkGA1UEBhMCQVUxDDAKBgNVBAgTA05TVzEPMA0GA1UEBxMGU3lkbmV5MQwwCgYDVQQKDANQSVQxCTAHBgNVBAsMADEYMBYGA1UEAwwPbGF3cmVuY2VwaXQuY29tMSUwIwYJKoZIhvcNAQkBDBZsYXdyZW5jZS5waXRAZ21haWwuY29tMB4XDTEyMDQyODAyMjIyOFoXDTMyMDQyMzAyMjIyOFowgYYxCzAJBgNVBAYTAkFVMQwwCgYDVQQIEwNOU1cxDzANBgNVBAcTBlN5ZG5leTEMMAoGA1UECgwDUElUMQkwBwYDVQQLDAAxGDAWBgNVBAMMD2xhd3JlbmNlcGl0LmNvbTElMCMGCSqGSIb3DQEJAQwWbGF3cmVuY2UucGl0QGdtYWlsLmNvbTCBnzANBgkqhkiG9w0BAQEFAAOBjQAwgYkCgYEAuBywPNlC1FopGLYfF96SotiK8Nj6/nW084O4omRMifzy7x955RLEy673q2aiJNB3LvE6Xvkt9cGtxtNoOXw1g2UvHKpldQbr6bOEjLNeDNW7j0ob+JrRvAUOK9CRgdyw5MC6lwqVQQ5C1DnaT/2fSBFjasBFTR24dEpfTy8HfKECAwEAAaOCASUwggEhMAkGA1UdEwQCMAAwCwYDVR0PBAQDAgUgMB0GA1UdDgQWBBQNBGmmt3ytKpcJaBaYNbnyU2xkazATBgNVHSUEDDAKBggrBgEFBQcDATAdBglghkgBhvhCAQ0EEBYOVGVzdCBYNTA5IGNlcnQwgbMGA1UdIwSBqzCBqIAUDQRpprd8rSqXCWgWmDW58lNsZGuhgYykgYkwgYYxCzAJBgNVBAYTAkFVMQwwCgYDVQQIEwNOU1cxDzANBgNVBAcTBlN5ZG5leTEMMAoGA1UECgwDUElUMQkwBwYDVQQLDAAxGDAWBgNVBAMMD2xhd3JlbmNlcGl0LmNvbTElMCMGCSqGSIb3DQEJAQwWbGF3cmVuY2UucGl0QGdtYWlsLmNvbYIBATANBgkqhkiG9w0BAQsFAAOBgQAEcVUPBX7uZmzqZJfy+tUPOT5ImNQj8VE2lerhnFjnGPHmHIqhpzgnwHQujJfs/a309Wm5qwcCaC1eO5cWjcG0x3OjdllsgYDatl5GAumtBx8J3NhWRqNUgitCIkQlxHIwUfgQaCushYgDDL5YbIQa++egCgpIZ+T0Dj5oRew//A==" }
     subject { described_class.new(
-      signed_info
+      signed_info,
+      x509_certificate
     ) }
 
     before do

--- a/spec/lib/saml_idp/signed_info_builder_spec.rb
+++ b/spec/lib/saml_idp/signed_info_builder_spec.rb
@@ -4,10 +4,14 @@ module SamlIdp
     let(:reference_id) { "abc" }
     let(:digest) { "em8csGAWynywpe8S4nN64o56/4DosXi2XWMY6RJ6YfA=" }
     let(:algorithm) { :sha256 }
+    let(:secret_key) { SamlIdp::Default::SECRET_KEY }
+    let(:password) { nil }
     subject { described_class.new(
       reference_id,
       digest,
-      algorithm
+      algorithm,
+      secret_key,
+      password
     ) }
 
     before do


### PR DESCRIPTION
I've had this feature in my fork and used it in Production for years, so I wanted to give it back to the community.

Just as https://github.com/saml-idp/saml_idp/pull/88, we want to change the IdP configuration such as x509cert, secret key, and password on the fly if the IDP is multitenancy, depending on who the customer is. 

You can change the configuration when returning a SAML response like so:
```
def create
        @saml_response = encode_response(current_user, {
          x509_certificate: "=== Valid Certificate ===",
          secret_key: "Valid Secret Key"
        })
        render template: "saml_idp/idp/saml_post", layout: false
end
```