### PR TITLE
Test logger interface instead of class

### DIFF
--- a/lib/saml_idp/request.rb
+++ b/lib/saml_idp/request.rb
@@ -78,10 +78,10 @@ module SamlIdp
     end
 
     def log(msg)
-      if config.logger.class <= ::Logger
-        config.logger.info msg
-      else
+      if config.logger.respond_to?(:call)
         config.logger.call msg
+      else
+        config.logger.info msg
       end
     end
 

--- a/spec/lib/saml_idp/request_spec.rb
+++ b/spec/lib/saml_idp/request_spec.rb
@@ -91,6 +91,23 @@ module SamlIdp
           end
         end
 
+        context 'a Logger-like logger is configured' do
+          let(:logger) do
+            Class.new {
+              def info(msg); end
+            }.new
+          end
+
+          before do
+            allow(logger).to receive(:info)
+          end
+
+          it 'logs an error message' do
+            expect(subject.valid?).to be false
+            expect(logger).to have_received(:info).with('Unable to find service provider for issuer ')
+          end
+        end
+
         context 'a logger lambda is configured' do
           let(:logger) { double }
 


### PR DESCRIPTION
Rails 7.1.0 introduces a new default logger class, `ActiveSupport::BroadcastLogger`, which does not inherit from `Logger`. (See: rails/rails#48615.)

Instead of testing for a specific class, we can test the interface.