### PR TITLE
Check for method instead of inheritance for info when logging

### DIFF
--- a/lib/saml_idp/request.rb
+++ b/lib/saml_idp/request.rb
@@ -78,7 +78,7 @@ module SamlIdp
     end
 
     def log(msg)
-      if config.logger.class <= ::Logger
+      if config.logger.respond_to?(:info)
         config.logger.info msg
       else
         config.logger.call msg


### PR DESCRIPTION
This PR changes a bug we see in our production Rails app. Currently we use Google Cloud's Logging class in production which [as you can see here](https://github.com/googleapis/google-cloud-ruby/blob/4fb678abe2bef0d2d8aed67fe6e1fd0ffac640c1/google-cloud-logging/lib/google/cloud/logging/logger.rb#L54) does not inherit from ActiveSupport's Logger Class. That said, it _does_ have an `info` method.

I've adjusted the if condition here so that we aren't getting 500s in production when saml-idp tries to log an INFO-level message when validation a SAML request.