### PR TITLE
Bug Fix: SAML Response Initialize Arguments Passed in the Wrong Order 

### DIFF
--- a/lib/saml_idp/controller.rb
+++ b/lib/saml_idp/controller.rb
@@ -81,8 +81,8 @@ module SamlIdp
         session_expiry,
         name_id_formats_opts,
         asserted_attributes_opts,
-        signed_assertion_opts,
         signed_message_opts,
+        signed_assertion_opts,
         compress_opts
       ).build
     end

--- a/spec/lib/saml_idp/controller_spec.rb
+++ b/spec/lib/saml_idp/controller_spec.rb
@@ -91,6 +91,12 @@ describe SamlIdp::Controller do
         expect(response.issuer).to eq("http://example.com")
       end
 
+      it "should by default create a SAML Response with a signed assertion" do
+        saml_response = encode_response(principal)
+        response = OneLogin::RubySaml::Response.new(saml_response)
+        response.settings = saml_settings("https://foo.example.com/saml/consume", true)
+        expect(response.is_valid?).to be_truthy
+      end
 
       [:sha1, :sha256, :sha384, :sha512].each do |algorithm_name|
         it "should create a SAML Response using the #{algorithm_name} algorithm" do

--- a/spec/support/saml_request_macros.rb
+++ b/spec/support/saml_request_macros.rb
@@ -40,7 +40,8 @@ module SamlRequestMacros
                                     logout_requests_signed: true, 
                                     logout_responses_signed: true,
                                     digest_method: XMLSecurity::Document::SHA256,
-                                    signature_method: XMLSecurity::Document::RSA_SHA256)
+                                    signature_method: XMLSecurity::Document::RSA_SHA256,
+                                    assertions_signed: true)
     # Security section
     settings.idp_cert = SamlIdp::Default::X509_CERTIFICATE
     # Signed embedded singature
@@ -51,6 +52,7 @@ module SamlRequestMacros
     settings.security[:metadata_signed] = digest_method
     settings.security[:digest_method] = digest_method
     settings.security[:signature_method] = signature_method
+    settings.security[:want_assertions_signed] = assertions_signed
     settings.private_key = sp_pv_key
     settings.certificate = sp_x509_cert
   end


### PR DESCRIPTION
This fixes an issue in the `SamlIdp::Controller#encode_authn_response` method where arguments where being passed in the wrong order. This issue was introduced in v0.15.0.

In the call to `SamlResponse#initialize` the value of `false` for `signed_message_opts` was, by default, getting passed as the argument for `signed_assertion_opts` which caused SAML Responses to be generated without a signed assertion.

This wasn't caught in the tests because signed assertions were not checked when validating the SAML response, so a test was added to confirm that the assertion is being signed by default.

This could present a potential security concern, as SAML assertions are typically signed by default. It is expected that SAML Service Providers (SPs) validate these signatures. However, if a user of this gem upgrades to version 0.15.0 and mistakenly assumes that the assertion signature continues to be transmitted, this could lead to a potential security vulnerability.