### PR TITLE
Extracts Saml::XML into SamlIdp::XML to free up the use of the Saml namespace

### DIFF
--- a/lib/saml_idp.rb
+++ b/lib/saml_idp.rb
@@ -2,6 +2,7 @@
 module SamlIdp
   require 'active_support/all'
   require 'saml_idp/saml_response'
+  require 'saml_idp/xml'
   require 'saml_idp/xml_security'
   require 'saml_idp/configurator'
   require 'saml_idp/controller'
@@ -21,73 +22,5 @@ module SamlIdp
 
   def self.metadata
     @metadata ||= MetadataBuilder.new(config)
-  end
-end
-
-# TODO Needs extraction out
-module Saml
-  module XML
-    module Namespaces
-      METADATA = "urn:oasis:names:tc:SAML:2.0:metadata"
-      ASSERTION = "urn:oasis:names:tc:SAML:2.0:assertion"
-      SIGNATURE = "http://www.w3.org/2000/09/xmldsig#"
-      PROTOCOL = "urn:oasis:names:tc:SAML:2.0:protocol"
-
-      module Statuses
-        SUCCESS = "urn:oasis:names:tc:SAML:2.0:status:Success"
-      end
-
-      module Consents
-        UNSPECIFIED = "urn:oasis:names:tc:SAML:2.0:consent:unspecified"
-      end
-
-      module AuthnContext
-        module ClassRef
-          PASSWORD = "urn:oasis:names:tc:SAML:2.0:ac:classes:Password"
-          PASSWORD_PROTECTED = "urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport"
-        end
-      end
-
-      module Methods
-        BEARER = "urn:oasis:names:tc:SAML:2.0:cm:bearer"
-      end
-
-      module Formats
-        module Attr
-          URI = "urn:oasis:names:tc:SAML:2.0:attrname-format:uri"
-        end
-
-        module NameId
-          EMAIL_ADDRESS = "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"
-          TRANSIENT = "urn:oasis:names:tc:SAML:2.0:nameid-format:transient"
-          PERSISTENT = "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent"
-        end
-      end
-    end
-
-    class Document < Nokogiri::XML::Document
-      def signed?
-        !!xpath("//ds:Signature", ds: signature_namespace).first
-      end
-
-      def valid_signature?(fingerprint)
-        signed? &&
-          signed_document.validate(fingerprint, :soft)
-      end
-
-      def signed_document
-        SamlIdp::XMLSecurity::SignedDocument.new(to_xml)
-      end
-
-      def signature_namespace
-        Namespaces::SIGNATURE
-      end
-
-      def to_xml
-        super(
-          save_with: Nokogiri::XML::Node::SaveOptions::AS_XML | Nokogiri::XML::Node::SaveOptions::NO_DECLARATION
-        ).strip
-      end
-    end
   end
 end

--- a/lib/saml_idp/assertion_builder.rb
+++ b/lib/saml_idp/assertion_builder.rb
@@ -53,7 +53,7 @@ module SamlIdp
 
     def fresh
       builder = Builder::XmlMarkup.new
-      builder.Assertion xmlns: Saml::XML::Namespaces::ASSERTION,
+      builder.Assertion xmlns: SamlIdp::XML::Namespaces::ASSERTION,
         ID: reference_string,
         IssueInstant: now_iso,
         Version: "2.0" do |assertion|
@@ -61,7 +61,7 @@ module SamlIdp
           sign assertion
           assertion.Subject do |subject|
             subject.NameID name_id, Format: name_id_format[:name]
-            subject.SubjectConfirmation Method: Saml::XML::Namespaces::Methods::BEARER do |confirmation|
+            subject.SubjectConfirmation Method: SamlIdp::XML::Namespaces::Methods::BEARER do |confirmation|
               confirmation_hash = {}
               confirmation_hash[:InResponseTo] = saml_request_id unless saml_request_id.nil?
               confirmation_hash[:NotOnOrAfter] = not_on_or_after_subject
@@ -92,7 +92,7 @@ module SamlIdp
               asserted_attributes.each do |friendly_name, attrs|
                 attrs = (attrs || {}).with_indifferent_access
                 attr_statement.Attribute Name: attrs[:name] || friendly_name,
-                  NameFormat: attrs[:name_format] || Saml::XML::Namespaces::Formats::Attr::URI,
+                  NameFormat: attrs[:name_format] || SamlIdp::XML::Namespaces::Formats::Attr::URI,
                   FriendlyName: friendly_name.to_s do |attr|
                     values = get_values_for friendly_name, attrs[:getter]
                     values.each do |val|

--- a/lib/saml_idp/attribute_decorator.rb
+++ b/lib/saml_idp/attribute_decorator.rb
@@ -17,7 +17,7 @@ module SamlIdp
     end
 
     def name_format
-      source[:name_format] || Saml::XML::Namespaces::Formats::Attr::URI
+      source[:name_format] || SamlIdp::XML::Namespaces::Formats::Attr::URI
     end
 
     def values

--- a/lib/saml_idp/controller.rb
+++ b/lib/saml_idp/controller.rb
@@ -45,7 +45,7 @@ module SamlIdp
     end
 
     def authn_context_classref
-      Saml::XML::Namespaces::AuthnContext::ClassRef::PASSWORD
+      SamlIdp::XML::Namespaces::AuthnContext::ClassRef::PASSWORD
     end
 
     def encode_authn_response(principal, opts = {})

--- a/lib/saml_idp/encryptor.rb
+++ b/lib/saml_idp/encryptor.rb
@@ -23,7 +23,7 @@ module SamlIdp
       encrypted_key = Xmlenc::EncryptedKey.new(encrypted_key_node)
       encrypted_key.encrypt(openssl_cert.public_key, encryption_key)
       xml = Builder::XmlMarkup.new
-      xml.EncryptedAssertion xmlns: Saml::XML::Namespaces::ASSERTION do |enc_assert|
+      xml.EncryptedAssertion xmlns: SamlIdp::XML::Namespaces::ASSERTION do |enc_assert|
         enc_assert << encrypted_data.node.to_s
       end 
     end

--- a/lib/saml_idp/incoming_metadata.rb
+++ b/lib/saml_idp/incoming_metadata.rb
@@ -13,7 +13,7 @@ module SamlIdp
     end
 
     def document
-      @document ||= Saml::XML::Document.parse raw
+      @document ||= SamlIdp::XML::Document.parse raw
     end
 
     def entity_id
@@ -149,16 +149,16 @@ module SamlIdp
     end
 
     def contact_person_document
-      @contact_person_document ||= (xpath("//md:ContactPerson", md: metadata_namespace).first || Saml::XML::Document.new)
+      @contact_person_document ||= (xpath("//md:ContactPerson", md: metadata_namespace).first || SamlIdp::XML::Document.new)
     end
 
     def metadata_namespace
-      Saml::XML::Namespaces::METADATA
+      SamlIdp::XML::Namespaces::METADATA
     end
     private :metadata_namespace
 
     def signature_namespace
-      Saml::XML::Namespaces::SIGNATURE
+      SamlIdp::XML::Namespaces::SIGNATURE
     end
     private :signature_namespace
   end

--- a/lib/saml_idp/logout_request_builder.rb
+++ b/lib/saml_idp/logout_request_builder.rb
@@ -14,11 +14,11 @@ module SamlIdp
         Version: "2.0",
         IssueInstant: now_iso,
         Destination: saml_slo_url,
-        "xmlns" => Saml::XML::Namespaces::PROTOCOL do |request|
-          request.Issuer issuer_uri, xmlns: Saml::XML::Namespaces::ASSERTION
+        "xmlns" => SamlIdp::XML::Namespaces::PROTOCOL do |request|
+          request.Issuer issuer_uri, xmlns: SamlIdp::XML::Namespaces::ASSERTION
           sign request
-          request.NameID name_id, xmlns: Saml::XML::Namespaces::ASSERTION,
-            Format: Saml::XML::Namespaces::Formats::NameId::PERSISTENT
+          request.NameID name_id, xmlns: SamlIdp::XML::Namespaces::ASSERTION,
+            Format: SamlIdp::XML::Namespaces::Formats::NameId::PERSISTENT
           request.SessionIndex response_id_string
         end
     end

--- a/lib/saml_idp/logout_response_builder.rb
+++ b/lib/saml_idp/logout_response_builder.rb
@@ -15,11 +15,11 @@ module SamlIdp
         IssueInstant: now_iso,
         Destination: saml_slo_url,
         InResponseTo: saml_request_id,
-        xmlns: Saml::XML::Namespaces::PROTOCOL do |response|
-          response.Issuer issuer_uri, xmlns: Saml::XML::Namespaces::ASSERTION
+        xmlns: SamlIdp::XML::Namespaces::PROTOCOL do |response|
+          response.Issuer issuer_uri, xmlns: SamlIdp::XML::Namespaces::ASSERTION
           sign response
-          response.Status xmlns: Saml::XML::Namespaces::PROTOCOL do |status|
-            status.StatusCode Value: Saml::XML::Namespaces::Statuses::SUCCESS
+          response.Status xmlns: SamlIdp::XML::Namespaces::PROTOCOL do |status|
+            status.StatusCode Value: SamlIdp::XML::Namespaces::Statuses::SUCCESS
           end
         end
     end

--- a/lib/saml_idp/metadata_builder.rb
+++ b/lib/saml_idp/metadata_builder.rb
@@ -16,9 +16,9 @@ module SamlIdp
       builder = Builder::XmlMarkup.new
       generated_reference_id do
         builder.EntityDescriptor ID: reference_string,
-          xmlns: Saml::XML::Namespaces::METADATA,
-          "xmlns:saml" => Saml::XML::Namespaces::ASSERTION,
-          "xmlns:ds" => Saml::XML::Namespaces::SIGNATURE,
+          xmlns: SamlIdp::XML::Namespaces::METADATA,
+          "xmlns:saml" => SamlIdp::XML::Namespaces::ASSERTION,
+          "xmlns:ds" => SamlIdp::XML::Namespaces::SIGNATURE,
           entityID: entity_id do |entity|
             sign entity
 
@@ -56,7 +56,7 @@ module SamlIdp
 
     def build_key_descriptor(el)
       el.KeyDescriptor use: "signing" do |key_descriptor|
-        key_descriptor.KeyInfo xmlns: Saml::XML::Namespaces::SIGNATURE do |key_info|
+        key_descriptor.KeyInfo xmlns: SamlIdp::XML::Namespaces::SIGNATURE do |key_info|
           key_info.X509Data do |x509|
             x509.X509Certificate x509_certificate
           end
@@ -128,7 +128,7 @@ module SamlIdp
     private :entity_id
 
     def protocol_enumeration
-      Saml::XML::Namespaces::PROTOCOL
+      SamlIdp::XML::Namespaces::PROTOCOL
     end
     private :protocol_enumeration
 

--- a/lib/saml_idp/request.rb
+++ b/lib/saml_idp/request.rb
@@ -157,7 +157,7 @@ module SamlIdp
     private :response_host
 
     def document
-      @_document ||= Saml::XML::Document.parse(raw_xml)
+      @_document ||= SamlIdp::XML::Document.parse(raw_xml)
     end
     private :document
 
@@ -179,17 +179,17 @@ module SamlIdp
     private :logout_request
 
     def samlp
-      Saml::XML::Namespaces::PROTOCOL
+      SamlIdp::XML::Namespaces::PROTOCOL
     end
     private :samlp
 
     def assertion
-      Saml::XML::Namespaces::ASSERTION
+      SamlIdp::XML::Namespaces::ASSERTION
     end
     private :assertion
 
     def signature_namespace
-      Saml::XML::Namespaces::SIGNATURE
+      SamlIdp::XML::Namespaces::SIGNATURE
     end
     private :signature_namespace
 

--- a/lib/saml_idp/response_builder.rb
+++ b/lib/saml_idp/response_builder.rb
@@ -47,16 +47,16 @@ module SamlIdp
       resp_options[:Version] =  "2.0"
       resp_options[:IssueInstant] = now_iso
       resp_options[:Destination] = saml_acs_url
-      resp_options[:Consent] = Saml::XML::Namespaces::Consents::UNSPECIFIED
+      resp_options[:Consent] = SamlIdp::XML::Namespaces::Consents::UNSPECIFIED
       resp_options[:InResponseTo] = saml_request_id unless saml_request_id.nil?
-      resp_options["xmlns:samlp"] = Saml::XML::Namespaces::PROTOCOL
+      resp_options["xmlns:samlp"] = SamlIdp::XML::Namespaces::PROTOCOL
 
       builder = Builder::XmlMarkup.new
       builder.tag! "samlp:Response", resp_options do |response|
-          response.Issuer issuer_uri, xmlns: Saml::XML::Namespaces::ASSERTION
+          response.Issuer issuer_uri, xmlns: SamlIdp::XML::Namespaces::ASSERTION
           sign response
           response.tag! "samlp:Status" do |status|
-            status.tag! "samlp:StatusCode", Value: Saml::XML::Namespaces::Statuses::SUCCESS
+            status.tag! "samlp:StatusCode", Value: SamlIdp::XML::Namespaces::Statuses::SUCCESS
           end
           response << assertion_and_signature
         end

--- a/lib/saml_idp/xml.rb
+++ b/lib/saml_idp/xml.rb
@@ -1,0 +1,66 @@
+module SamlIdp
+  module XML
+    module Namespaces
+      METADATA = "urn:oasis:names:tc:SAML:2.0:metadata"
+      ASSERTION = "urn:oasis:names:tc:SAML:2.0:assertion"
+      SIGNATURE = "http://www.w3.org/2000/09/xmldsig#"
+      PROTOCOL = "urn:oasis:names:tc:SAML:2.0:protocol"
+
+      module Statuses
+        SUCCESS = "urn:oasis:names:tc:SAML:2.0:status:Success"
+      end
+
+      module Consents
+        UNSPECIFIED = "urn:oasis:names:tc:SAML:2.0:consent:unspecified"
+      end
+
+      module AuthnContext
+        module ClassRef
+          PASSWORD = "urn:oasis:names:tc:SAML:2.0:ac:classes:Password"
+          PASSWORD_PROTECTED = "urn:oasis:names:tc:SAML:2.0:ac:classes:PasswordProtectedTransport"
+        end
+      end
+
+      module Methods
+        BEARER = "urn:oasis:names:tc:SAML:2.0:cm:bearer"
+      end
+
+      module Formats
+        module Attr
+          URI = "urn:oasis:names:tc:SAML:2.0:attrname-format:uri"
+        end
+
+        module NameId
+          EMAIL_ADDRESS = "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress"
+          TRANSIENT = "urn:oasis:names:tc:SAML:2.0:nameid-format:transient"
+          PERSISTENT = "urn:oasis:names:tc:SAML:2.0:nameid-format:persistent"
+        end
+      end
+    end
+
+    class Document < Nokogiri::XML::Document
+      def signed?
+        !!xpath("//ds:Signature", ds: signature_namespace).first
+      end
+
+      def valid_signature?(fingerprint)
+        signed? &&
+          signed_document.validate(fingerprint, :soft)
+      end
+
+      def signed_document
+        SamlIdp::XMLSecurity::SignedDocument.new(to_xml)
+      end
+
+      def signature_namespace
+        Namespaces::SIGNATURE
+      end
+
+      def to_xml
+        super(
+          save_with: Nokogiri::XML::Node::SaveOptions::AS_XML | Nokogiri::XML::Node::SaveOptions::NO_DECLARATION
+        ).strip
+      end
+    end
+  end
+end

--- a/spec/lib/saml_idp/assertion_builder_spec.rb
+++ b/spec/lib/saml_idp/assertion_builder_spec.rb
@@ -9,7 +9,7 @@ module SamlIdp
     let(:saml_acs_url) { "http://saml.acs.url" }
     let(:algorithm) { :sha256 }
     let(:authn_context_classref) {
-      Saml::XML::Namespaces::AuthnContext::ClassRef::PASSWORD
+      SamlIdp::XML::Namespaces::AuthnContext::ClassRef::PASSWORD
     }
     let(:expiry) { 3*60*60 }
     let (:encryption_opts) do

--- a/spec/lib/saml_idp/attribute_decorator_spec.rb
+++ b/spec/lib/saml_idp/attribute_decorator_spec.rb
@@ -20,7 +20,7 @@ module SamlIdp
     end
 
     it "has a valid name_format" do
-      expect(subject.name_format).to eq(Saml::XML::Namespaces::Formats::Attr::URI)
+      expect(subject.name_format).to eq(SamlIdp::XML::Namespaces::Formats::Attr::URI)
     end
 
     it "has a valid values" do

--- a/spec/lib/saml_idp/metadata_builder_spec.rb
+++ b/spec/lib/saml_idp/metadata_builder_spec.rb
@@ -6,7 +6,7 @@ module SamlIdp
     end
 
     it "signs valid xml" do
-      expect(Saml::XML::Document.parse(subject.signed).valid_signature?(Default::FINGERPRINT)).to be_truthy
+      expect(SamlIdp::XML::Document.parse(subject.signed).valid_signature?(Default::FINGERPRINT)).to be_truthy
     end
 
     it "includes logout element" do

--- a/spec/lib/saml_idp/saml_response_spec.rb
+++ b/spec/lib/saml_idp/saml_response_spec.rb
@@ -13,7 +13,7 @@ module SamlIdp
     let(:x509_certificate) { Default::X509_CERTIFICATE }
     let(:xauthn) { Default::X509_CERTIFICATE }
     let(:authn_context_classref) {
-      Saml::XML::Namespaces::AuthnContext::ClassRef::PASSWORD
+      SamlIdp::XML::Namespaces::AuthnContext::ClassRef::PASSWORD
     }
     let(:expiry) { 3 * 60 * 60 }
     let(:session_expiry) { 24 * 60 * 60 }


### PR DESCRIPTION
### What this PR does: 
- moves XML module out of the `Saml` namespace and into `SamlIdp` [^1]
- updates references from `Saml::XML` to `SamlIdp::XML`

## Why
Defining such a generic namespace as `Saml` in this gem causes namespace collisions for projects attempting to use saml-idp which may define their own `Saml` module. We shouldn't do that here. There was even a note to that affect in the form of a long standing `TODO` item to extract this.

[^1]: This is opinionated to avoid the repetition of `SamlIdp::Saml::Xml`