### PR TITLE
Alternative to support multiple x509 Certificates via procs

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Be sure to load a file like this during your app initialization:
 ```ruby
 SamlIdp.configure do |config|
   base = "http://example.com"
-
+  
   config.x509_certificate = <<-CERT
 -----BEGIN CERTIFICATE-----
 CERTIFICATE DATA
@@ -73,6 +73,11 @@ CERT
 KEY DATA
 -----END RSA PRIVATE KEY-----
 CERT
+
+  # x509_certificate, secret_key, and password may also be set from within a proc, for example:
+  # config.x509_certificate = -> { File.read("cert.pem") }
+  # config.secret_key = -> { SecretKeyFinder.key_for(id: 1) }
+  # config.password = -> { "password" }
 
   # config.password = "secret_key_password"
   # config.algorithm = :sha256                                    # Default: sha1 only for development.

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ Be sure to load a file like this during your app initialization:
 ```ruby
 SamlIdp.configure do |config|
   base = "http://example.com"
-  
+
   config.x509_certificate = <<-CERT
 -----BEGIN CERTIFICATE-----
 CERTIFICATE DATA

--- a/lib/saml_idp/configurator.rb
+++ b/lib/saml_idp/configurator.rb
@@ -25,8 +25,9 @@ module SamlIdp
     attr_accessor :logger
 
     def initialize
-      self.x509_certificate = Default::X509_CERTIFICATE
-      self.secret_key = Default::SECRET_KEY
+      self.x509_certificate = -> { Default::X509_CERTIFICATE }
+      self.secret_key = -> { Default::SECRET_KEY }
+      self.password = nil
       self.algorithm = :sha1
       self.reference_id_generator = ->() { SecureRandom.uuid }
       self.service_provider = OpenStruct.new

--- a/lib/saml_idp/configurator.rb
+++ b/lib/saml_idp/configurator.rb
@@ -27,7 +27,6 @@ module SamlIdp
     def initialize
       self.x509_certificate = -> { Default::X509_CERTIFICATE }
       self.secret_key = -> { Default::SECRET_KEY }
-      self.password = nil
       self.algorithm = :sha1
       self.reference_id_generator = ->() { SecureRandom.uuid }
       self.service_provider = OpenStruct.new

--- a/lib/saml_idp/metadata_builder.rb
+++ b/lib/saml_idp/metadata_builder.rb
@@ -152,7 +152,8 @@ module SamlIdp
     private :raw_algorithm
 
     def x509_certificate
-      SamlIdp.config.x509_certificate
+      certificate = SamlIdp.config.x509_certificate.is_a?(Proc) ? SamlIdp.config.x509_certificate.call : SamlIdp.config.x509_certificate
+      certificate
       .to_s
       .gsub(/-----BEGIN CERTIFICATE-----/,"")
       .gsub(/-----END CERTIFICATE-----/,"")

--- a/lib/saml_idp/signature_builder.rb
+++ b/lib/saml_idp/signature_builder.rb
@@ -21,7 +21,8 @@ module SamlIdp
     end
 
     def x509_certificate
-      SamlIdp.config.x509_certificate
+      certificate = SamlIdp.config.x509_certificate.is_a?(Proc) ? SamlIdp.config.x509_certificate.call : SamlIdp.config.x509_certificate
+      certificate
       .to_s
       .gsub(/-----BEGIN CERTIFICATE-----/,"")
       .gsub(/-----END CERTIFICATE-----/,"")

--- a/lib/saml_idp/signed_info_builder.rb
+++ b/lib/saml_idp/signed_info_builder.rb
@@ -65,12 +65,12 @@ module SamlIdp
     private :clean_algorithm_name
 
     def secret_key
-      SamlIdp.config.secret_key
+      SamlIdp.config.secret_key.is_a?(Proc) ? SamlIdp.config.secret_key.call : SamlIdp.config.secret_key
     end
     private :secret_key
 
     def password
-      SamlIdp.config.password
+      SamlIdp.config.password.is_a?(Proc) ? SamlIdp.config.password.call : SamlIdp.config.password
     end
     private :password
 

--- a/spec/lib/saml_idp/configurator_spec.rb
+++ b/spec/lib/saml_idp/configurator_spec.rb
@@ -20,11 +20,11 @@ module SamlIdp
     it { should respond_to :logger }
 
     it "has a valid x509_certificate" do
-      expect(subject.x509_certificate).to eq(Default::X509_CERTIFICATE)
+      expect(subject.x509_certificate.call).to eq(Default::X509_CERTIFICATE)
     end
 
     it "has a valid secret_key" do
-      expect(subject.secret_key).to eq(Default::SECRET_KEY)
+      expect(subject.secret_key.call).to eq(Default::SECRET_KEY)
     end
 
     it "has a valid algorithm" do


### PR DESCRIPTION
### What this PR does
- allows for looking up x509 certificates with a proc in the SamlIdp config
- calls the proc or falls back to the original behavior where appropriate
- adds short example in the REDME documentation

### Why

This is an alternative approach to supporting multiple x509 certificates, secret keys, and password. This uses procs in the SamlIdp configuration as an alternative to #186 and #209.

I have been using this approach for some time now using a service object as a finder for the appropriate cert and secret key.

Some examples for looking these up:

```ruby
config.x509_certificate = -> { File.read("cert.pem") }
config.secret_key = -> { SecretKeyFinder.key_for(id: 1) }
config.password = -> { Rails.application.credentials.dig(:saml_idp, :password ) }
```