### PR TITLE
Check if Rails is fully initialized

### DIFF
--- a/lib/saml_idp.rb
+++ b/lib/saml_idp.rb
@@ -9,7 +9,7 @@ module SamlIdp
   require 'saml_idp/metadata_builder'
   require 'saml_idp/version'
   require 'saml_idp/fingerprint'
-  require 'saml_idp/engine' if defined?(::Rails)
+  require 'saml_idp/engine' if defined?(::Rails::Engine)
 
   def self.config
     @config ||= SamlIdp::Configurator.new

--- a/lib/saml_idp/configurator.rb
+++ b/lib/saml_idp/configurator.rb
@@ -35,7 +35,7 @@ module SamlIdp
       self.service_provider.persisted_metadata_getter = ->(id, service_provider) {  }
       self.session_expiry = 0
       self.attributes = {}
-      self.logger = defined?(::Rails) ? Rails.logger : ->(msg) { puts msg }
+      self.logger = (defined?(::Rails) && Rails.respond_to?(:logger)) ? Rails.logger : ->(msg) { puts msg }
     end
 
     # formats

--- a/spec/lib/saml_idp/configurator_spec.rb
+++ b/spec/lib/saml_idp/configurator_spec.rb
@@ -47,5 +47,34 @@ module SamlIdp
     it 'has a valid session_expiry' do
       expect(subject.session_expiry).to eq(0)
     end
+
+    context "logger initialization" do
+      context 'when Rails has been properly initialized' do
+        it 'sets logger to Rails.logger' do
+          rails_logger = double("Rails.logger")
+          stub_const("Rails", double(logger: rails_logger))
+
+          expect(subject.logger).to eq(Rails.logger)
+        end
+      end
+
+      context 'when Rails is not fully initialized' do
+        it 'sets logger to a lambda' do
+          stub_const("Rails", Class.new)
+
+          expect(subject.logger).to be_a(Proc)
+          expect { subject.logger.call("test") }.to output("test\n").to_stdout
+        end
+      end
+
+      context 'when Rails is not defined' do
+        it 'sets logger to a lambda' do
+          hide_const("Rails")
+
+          expect(subject.logger).to be_a(Proc)
+          expect { subject.logger.call("test") }.to output("test\n").to_stdout
+        end
+      end
+    end
   end
 end


### PR DESCRIPTION
There is a case where the Rails gem is required but not fully initialized, such as when we require the ActionView gem. Therefore, instead of just checking if the `Rails` constant is available, we should be more precise and check if the required subsystem is available or initialized for us.