### PR TITLE
Fix warning: ostruct was loaded from the standard library

### DIFF
--- a/saml_idp.gemspec
+++ b/saml_idp.gemspec
@@ -46,6 +46,7 @@ Gem::Specification.new do |s|
   s.add_dependency('activesupport', '>= 5.2')
   s.add_dependency('builder', '>= 3.0')
   s.add_dependency('nokogiri', '>= 1.6.2')
+  s.add_dependency('ostruct')
   s.add_dependency('rexml')
   s.add_dependency('xmlenc', '>= 0.7.1')
 


### PR DESCRIPTION
It fixes a warning of loading ostruct gem from standard library with Ruby 3.3.5 and 3.4+.

The warning message is following:

```
/path/saml_idp/lib/saml_idp.rb:2: warning: ostruct was loaded from the standard library, but will no longer be part of the default gems starting from Ruby 3.5.0.
You can add ostruct to your Gemfile or gemspec to silence this warning.
```

- ruby: 3.3.5
- saml_idp gem: 1.6.0

### Related Links
- https://github.com/ruby/ruby/pull/10428
- https://bugs.ruby-lang.org/issues/20309
