### PR TITLE
Revert "Set minimum test coverage"

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,5 @@
 # encoding: utf-8
 require 'simplecov'
-SimpleCov.minimum_coverage 96.45
 SimpleCov.start do
   add_filter "/spec/"
 end


### PR DESCRIPTION
It was too early to set up this because it has a lot of nonsensical unit tests. Let’s revert this and focus a bit on the behavioral test of the SAML 2.0 workflow.