### PR TITLE
[bug] Make assertion signature flag switchable

### DIFF
--- a/lib/saml_idp/controller.rb
+++ b/lib/saml_idp/controller.rb
@@ -69,7 +69,7 @@ module SamlIdp
       signed_message_opts = opts[:signed_message] || false
       name_id_formats_opts = opts[:name_id_formats] || nil
       asserted_attributes_opts = opts[:attributes] || nil
-      signed_assertion_opts = opts[:signed_assertion] || true
+      signed_assertion_opts = opts[:signed_assertion].nil? ? true : opts[:signed_assertion]
       compress_opts = opts[:compress] || false
 
       SamlResponse.new(

--- a/spec/lib/saml_idp/controller_spec.rb
+++ b/spec/lib/saml_idp/controller_spec.rb
@@ -66,6 +66,16 @@ describe SamlIdp::Controller do
       end
     end
 
+    context '#encode_authn_response' do
+      it 'uses default values when opts are not provided' do
+        saml_response = encode_authn_response(principal, { audience_uri: 'http://example.com/issuer', issuer_uri: 'http://example.com', acs_url: 'https://foo.example.com/saml/consume', signed_assertion: false })
+
+        response = OneLogin::RubySaml::Response.new(saml_response)
+        response.settings = saml_settings
+        expect(response.document.to_s).to_not include("<ds:Signature>")
+      end
+    end
+
     context "solicited Response" do
       before(:each) do
         params[:SAMLRequest] = make_saml_request


### PR DESCRIPTION
Setting `nil` and `false` for `signed_assertion` always results in `true`, preventing the application from changing the value.