### PR TITLE
Load SP cert from metadata unless given in config

### DIFF
--- a/lib/saml_idp/persisted_metadata.rb
+++ b/lib/saml_idp/persisted_metadata.rb
@@ -2,6 +2,9 @@ require 'saml_idp/attributeable'
 module SamlIdp
   class PersistedMetadata
     include Attributeable
+    attribute :signing_certificate
+    attribute :encryption_certificate
+    attribute :unspecified_certificate
 
     def sign_assertions?
       !!attributes[:sign_assertions]

--- a/lib/saml_idp/request.rb
+++ b/lib/saml_idp/request.rb
@@ -148,7 +148,7 @@ module SamlIdp
     def valid_signature?
       # Force signatures for logout requests because there is no other protection against a cross-site DoS.
       if logout_request? || authn_request? && validate_auth_request_signature?
-        document.valid_signature?(service_provider.cert, service_provider.fingerprint)
+        service_provider.valid_signature?(document)
       else
         true
       end
@@ -260,11 +260,7 @@ module SamlIdp
     private :service_provider_finder
 
     def validate_auth_request_signature?
-      # Validate signature when metadata specify AuthnRequest should be signed
-      metadata = service_provider.current_metadata
-      sign_authn_request = metadata.respond_to?(:sign_authn_request?) && metadata.sign_authn_request?
-      sign_authn_request = service_provider.sign_authn_request unless service_provider.sign_authn_request.nil? 
-      sign_authn_request
+      service_provider.sign_authn_request?
     end
     private :validate_auth_request_signature?
   end

--- a/lib/saml_idp/service_provider.rb
+++ b/lib/saml_idp/service_provider.rb
@@ -7,11 +7,8 @@ module SamlIdp
   class ServiceProvider
     include Attributeable
     attribute :identifier
-    attribute :cert
     attribute :fingerprint
     attribute :metadata_url
-    attribute :validate_signature
-    attribute :sign_authn_request
     attribute :acs_url
     attribute :assertion_consumer_logout_service_url
     attribute :response_hosts
@@ -22,17 +19,26 @@ module SamlIdp
       attributes.present?
     end
 
-    def valid_signature?(doc, require_signature = false)
-      if require_signature || attributes[:validate_signature]
-        doc.valid_signature?(fingerprint)
-      else
-        true
-      end
+    def cert
+      attributes.fetch(:cert) { |_| current_metadata&.signing_certificate }
+    end
+
+    def validate_metadata_signature?
+      !!attributes[:validate_signature]
+    end
+
+    def sign_authn_request?
+      attributes.fetch(:sign_authn_request) { |_| current_metadata&.sign_authn_request? }
+    end
+
+    def valid_signature?(doc, certificate = cert)
+      doc.valid_signature?(certificate, fingerprint)
     end
 
     def refresh_metadata
       fresh = fresh_incoming_metadata
-      if valid_signature?(fresh.document)
+      cert = attributes[:cert] || fresh.signing_certificate
+      if !validate_metadata_signature? || valid_signature?(fresh.document, cert)
         metadata_persister[identifier, fresh]
         @current_metadata = nil
         fresh

--- a/spec/lib/saml_idp/request_spec.rb
+++ b/spec/lib/saml_idp/request_spec.rb
@@ -49,20 +49,21 @@ RSpec.describe SamlIdp::Request, type: :model do
 
   describe "#valid?" do
     let(:sp_issuer) { "test_issuer" }
-    let(:valid_service_provider) do 
+    let(:valid_service_provider) do
       instance_double(
         "SamlIdp::ServiceProvider",
         valid?: true,
         acs_url: 'https://foo.example.com/saml/consume',
         current_metadata: instance_double("Metadata", sign_authn_request?: true),
         assertion_consumer_logout_service_url: 'https://foo.example.com/saml/logout',
-        sign_authn_request: true,
+        sign_authn_request?: true,
         acceptable_response_hosts: ["foo.example.com"],
+        valid_signature?: true,
         cert: sp_x509_cert,
         fingerprint: SamlIdp::Fingerprint.certificate_digest(sp_x509_cert, :sha256),
       )
     end
-    
+
     before do
       allow_any_instance_of(SamlIdp::Request).to receive(:service_provider).and_return(valid_service_provider)
       allow_any_instance_of(SamlIdp::Request).to receive(:issuer).and_return(sp_issuer)
@@ -122,14 +123,14 @@ RSpec.describe SamlIdp::Request, type: :model do
     end
 
     context "when empty certificate for authn request validation" do
-      let(:valid_service_provider) do 
+      let(:valid_service_provider) do
         instance_double(
           "SamlIdp::ServiceProvider",
           valid?: true,
           acs_url: 'https://foo.example.com/saml/consume',
           current_metadata: instance_double("Metadata", sign_authn_request?: true),
           assertion_consumer_logout_service_url: 'https://foo.example.com/saml/logout',
-          sign_authn_request: true,
+          sign_authn_request?: true,
           acceptable_response_hosts: ["foo.example.com"],
           cert: nil,
           fingerprint: nil,
@@ -144,14 +145,14 @@ RSpec.describe SamlIdp::Request, type: :model do
     end
 
     context "when empty certificate for logout validation" do
-      let(:valid_service_provider) do 
+      let(:valid_service_provider) do
         instance_double(
           "SamlIdp::ServiceProvider",
           valid?: true,
           acs_url: 'https://foo.example.com/saml/consume',
           current_metadata: instance_double("Metadata", sign_authn_request?: true),
           assertion_consumer_logout_service_url: 'https://foo.example.com/saml/logout',
-          sign_authn_request: true,
+          sign_authn_request?: true,
           acceptable_response_hosts: ["foo.example.com"],
           cert: nil,
           fingerprint: nil,


### PR DESCRIPTION
This PR makes it easier to configure an SP by allowing the cert to be loaded from metadata (while still matching the fingerprint hardcoded in the config).

This doesn't appear to be any less secure than specifying both the cert and fingerprint by hand, since signature validation will favor the cert included in the message over the configured one anyway.

I also cleaned up the request class a bit by delegating to the ServiceProvider more.