### PR TITLE
Add Ruby 3.4 and Rails 8.0/7.2 to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ['2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3']
+        ruby: ['2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3', '3.4']
         gemfile: [rails_5.2.gemfile, rails_6.1.gemfile, rails_7.0.gemfile, rails_7.1.gemfile, rails_7.2.gemfile, rails_dev.gemfile]
         exclude:
           # Ruby 3.2 is min version for Rails 8
@@ -24,14 +24,17 @@ jobs:
             gemfile: rails_dev.gemfile
           - ruby: '3.1'
             gemfile: rails_dev.gemfile
+          # Ruby 3.2 is min version for Rails 8.0
           - ruby: '2.5'
-            gemfile: rails_7.0.gemfile
-          - ruby: '2.5'
-            gemfile: rails_7.1.gemfile
+            gemfile: rails_8.0.gemfile
           - ruby: '2.6'
-            gemfile: rails_7.0.gemfile
-          - ruby: '2.6'
-            gemfile: rails_7.1.gemfile
+            gemfile: rails_8.0.gemfile
+          - ruby: '2.7'
+            gemfile: rails_8.0.gemfile
+          - ruby: '3.0'
+            gemfile: rails_8.0.gemfile
+          - ruby: '3.1'
+            gemfile: rails_8.0.gemfile
           # Ruby 3.1 is min version for Rails 7.2
           - ruby: '2.5'
             gemfile: rails_7.2.gemfile
@@ -41,6 +44,17 @@ jobs:
             gemfile: rails_7.2.gemfile
           - ruby: '3.0'
             gemfile: rails_7.2.gemfile
+          # Ruby 2.7 is min version for Rails 7.1
+          - ruby: '2.5'
+            gemfile: rails_7.1.gemfile
+          - ruby: '2.6'
+            gemfile: rails_7.1.gemfile
+          # Ruby 2.7 is min version for Rails 7.0
+          - ruby: '2.5'
+            gemfile: rails_7.0.gemfile
+          - ruby: '2.6'
+            gemfile: rails_7.0.gemfile
+          # Ruby 2.7 is max version for Rails 5.2
           - ruby: '3.0'
             gemfile: rails_5.2.gemfile
           - ruby: '3.1'
@@ -48,6 +62,8 @@ jobs:
           - ruby: '3.2'
             gemfile: rails_5.2.gemfile
           - ruby: '3.3'
+            gemfile: rails_5.2.gemfile
+          - ruby: '3.4'
             gemfile: rails_5.2.gemfile
     runs-on: ubuntu-latest
     env:

--- a/Appraisals
+++ b/Appraisals
@@ -6,15 +6,31 @@ end
 appraise 'rails-6.1' do
   gem 'rails', '~> 6.1.0'
   gem 'activeresource', '~> 5.1.0'
+  gem 'bigdecimal'
+  gem 'mutex_m'
+  gem 'concurrent-ruby', '1.3.4'
 end
 
 appraise 'rails-7.0' do
   gem 'rails', '~> 7.0.0'
   gem 'activeresource', '~> 6.0.0'
+  gem 'bigdecimal'
+  gem 'mutex_m'
+  gem 'concurrent-ruby', '1.3.4'
 end
 
 appraise 'rails-7.1' do
   gem 'rails', '~> 7.1.0'
+  gem 'activeresource', '~> 6.0.0'
+end
+
+appraise 'rails-7.2' do
+  gem 'rails', '~> 7.2.0'
+  gem 'activeresource', '~> 6.0.0'
+end
+
+appraise 'rails-8.0' do
+  gem 'rails', '~> 8.0.0'
   gem 'activeresource', '~> 6.0.0'
 end
 

--- a/gemfiles/rails_6.1.gemfile
+++ b/gemfiles/rails_6.1.gemfile
@@ -4,6 +4,8 @@ source "https://rubygems.org"
 
 gem "rails", "~> 6.1.0"
 gem "activeresource", "~> 5.1.0"
-gem 'concurrent-ruby', '1.3.4'
+gem "bigdecimal"
+gem "mutex_m"
+gem "concurrent-ruby", "1.3.4"
 
 gemspec path: "../"

--- a/gemfiles/rails_7.0.gemfile
+++ b/gemfiles/rails_7.0.gemfile
@@ -4,6 +4,8 @@ source "https://rubygems.org"
 
 gem "rails", "~> 7.0.0"
 gem "activeresource", "~> 6.0.0"
-gem 'concurrent-ruby', '1.3.4'
+gem "bigdecimal"
+gem "mutex_m"
+gem "concurrent-ruby", "1.3.4"
 
 gemspec path: "../"

--- a/gemfiles/rails_8.0.gemfile
+++ b/gemfiles/rails_8.0.gemfile
@@ -2,7 +2,7 @@
 
 source "https://rubygems.org"
 
-gem "rails", "~> 7.2.0"
+gem "rails", "~> 8.0.0"
 gem "activeresource", "~> 6.0.0"
 
 gemspec path: "../"


### PR DESCRIPTION
This Pull Request adds Ruby 3.4 and Rails 8.0/7.2 to the CI matrix.

#### Additional Information
The `bigdecimal` and `mutex_m` gems have been added to the Appraisals file for Rails versions <= 7.0.
This is necessary because these gems were changed from default gems to bundled gems in Ruby 3.4 and later, and bundled gems must be explicitly declared.
- https://bugs.ruby-lang.org/issues/20187

Additionally, `concurrent-ruby` v1.3.4 has been added for compatibility with Rails versions <= 7.1.
This resolves an error that occurs with Rails <= 7.0 and `concurrent-ruby` v1.3.5:
- https://github.com/rails/rails/issues/54260
