### PR TITLE
SamlIDP v1

### DIFF
--- a/lib/saml_idp/version.rb
+++ b/lib/saml_idp/version.rb
@@ -1,4 +1,4 @@
 # encoding: utf-8
 module SamlIdp
-  VERSION = '0.16.0'
+  VERSION = '1.0.0'
 end


### PR DESCRIPTION
In PR #224: the gem previously auto-rendered `head :forbidden` when SAML request validation failed, but now exposes errors via request.errors and requires applications to handle the rendering themselves.

From the PR comments:
```ruby
# Old behavior (automatic):
head :forbidden if defined?(::Rails)

# New behavior (manual):
return true if valid_saml_request?
```

### Application must now check request.errors and handle accordingly

This breaks existing applications that relied on automatic error responses.

@Zogoo: "This was not UX friendly option that rendered a black screen from the gem. We should leave this decision to the application side."

Other significant changes:

* PR #211: Config values (x509_certificate, secret_key, password) can now be procs, not just strings
* PR #224: Adds unspecified_certificate support and SLO validation
Various signature validation improvements

Per semantic versioning, API changes that break existing implementations require a major version bump.