### PR TITLE
CI: Follow up to add Rails 8.0 to CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
       fail-fast: false
       matrix:
         ruby: ['2.5', '2.6', '2.7', '3.0', '3.1', '3.2', '3.3', '3.4']
-        gemfile: [rails_5.2.gemfile, rails_6.1.gemfile, rails_7.0.gemfile, rails_7.1.gemfile, rails_7.2.gemfile, rails_dev.gemfile]
+        gemfile: [rails_5.2.gemfile, rails_6.1.gemfile, rails_7.0.gemfile, rails_7.1.gemfile, rails_7.2.gemfile, rails_8.0.gemfile, rails_dev.gemfile]
         exclude:
           # Ruby 3.2 is min version for Rails 8
           - ruby: '2.5'


### PR DESCRIPTION
This Pull Request adds Rails 8.0 to the CI matrix.
It was missing from the CI matrix in #236.
