### PR TITLE
Add AssertionExtension for extensible SAML assertions

### DIFF
--- a/lib/saml_idp/assertion_builder.rb
+++ b/lib/saml_idp/assertion_builder.rb
@@ -87,10 +87,10 @@ module SamlIdp
               confirmation_hash[:InResponseTo] = saml_request_id unless saml_request_id.nil?
               confirmation_hash[:NotOnOrAfter] = not_on_or_after_subject
               confirmation_hash[:Recipient] = saml_acs_url
-              if assertion_extension.present? && assertion_extension.extension_point == AssertionExtension::SUBJECT_CONFIRMATION_DATA_EXTENSION_POINT
-                assertion_extension.build confirmation
-              else
-                confirmation.SubjectConfirmationData "", confirmation_hash
+              confirmation.SubjectConfirmationData confirmation_hash do |confirmation_data|
+                if assertion_extension.present? && assertion_extension.extension_point == AssertionExtension::SUBJECT_CONFIRMATION_DATA_EXTENSION_POINT
+                  assertion_extension.build confirmation_data
+                end
               end
             end
           end

--- a/lib/saml_idp/assertion_extension.rb
+++ b/lib/saml_idp/assertion_extension.rb
@@ -1,6 +1,10 @@
 require "builder"
 
 module SamlIdp
+  # Base class for extending the SAML 2.0 assertion at defined extension points.
+  # Aligns with OASIS SAML 2.0 Core: SubjectConfirmationData (2.4.1.2) allows arbitrary
+  # elements/attributes; AuthnContext (2.7.2.2) allows AuthnContextDecl by value.
+  # See docs/assertion_extension_saml_spec_analysis.md for spec analysis.
   class AssertionExtension
     SUBJECT_CONFIRMATION_DATA_EXTENSION_POINT = "SubjectConfirmationData"
     AUTHN_CONTEXT_DECL_EXTENSION_POINT = "AuthnContextDecl"
@@ -11,7 +15,13 @@ module SamlIdp
       self.extension_point = extension_point
     end
 
-    # This is an abstract base class, an example extension may look like this:
+    # Subclasses must implement build(context). The context is a Builder block for
+    # either SubjectConfirmation (for SubjectConfirmationData) or AuthnContext (for AuthnContextDecl).
+    #
+    # For SUBJECT_CONFIRMATION_DATA: emit SubjectConfirmationData with standard attributes
+    # (NotOnOrAfter, Recipient, InResponseTo when using bearer) and add custom elements inside it.
+    #
+    # Example (AuthnContextDecl extension):
     #
     # context.AuthnContextDecl do |builder|
     #   builder.AuthenticationContextDeclaration xmlns: "urn:my_org:saml:2.0:Device" do |context|

--- a/lib/saml_idp/assertion_extension.rb
+++ b/lib/saml_idp/assertion_extension.rb
@@ -1,0 +1,32 @@
+require "builder"
+
+module SamlIdp
+  class AssertionExtension
+    SUBJECT_CONFIRMATION_DATA_EXTENSION_POINT = "SubjectConfirmationData"
+    AUTHN_CONTEXT_DECL_EXTENSION_POINT = "AuthnContextDecl"
+
+    attr_accessor :extension_point
+
+    def initialize(extension_point)
+      self.extension_point = extension_point
+    end
+
+    # This is an abstract base class, an example extension may look like this:
+    #
+    # context.AuthnContextDecl do |builder|
+    #   builder.AuthenticationContextDeclaration xmlns: "urn:my_org:saml:2.0:Device" do |context|
+    #     context.Extension do |ext|
+    #       ext.Device xmlns: "urn:my_org:saml:2.0:ZeroTrust", ID: "f659c992-2b3d-4e2d-a155-6d32161e6754" do |device|
+    #         device.Trust do |trust|
+    #           trust.Data Name: "Managed", Value: true
+    #           trust.Data Name: "Compliant", Value: true
+    #         end
+    #       end
+    #     end
+    #   end
+    # end
+    def build(context)
+      raise "#{self.class} must implement build method"
+    end
+  end
+end

--- a/lib/saml_idp/assertion_extension.rb
+++ b/lib/saml_idp/assertion_extension.rb
@@ -15,11 +15,18 @@ module SamlIdp
       self.extension_point = extension_point
     end
 
-    # Subclasses must implement build(context). The context is a Builder block for
-    # either SubjectConfirmation (for SubjectConfirmationData) or AuthnContext (for AuthnContextDecl).
+    # Subclasses must implement build(context). Both extension points are additive:
+    # standard SAML elements are always emitted, and the extension adds content
+    # inside them.
     #
-    # For SUBJECT_CONFIRMATION_DATA: emit SubjectConfirmationData with standard attributes
-    # (NotOnOrAfter, Recipient, InResponseTo when using bearer) and add custom elements inside it.
+    # For SUBJECT_CONFIRMATION_DATA: The standard SubjectConfirmationData element
+    # with NotOnOrAfter, Recipient, and InResponseTo attributes is always emitted.
+    # The extension receives the SubjectConfirmationData builder to add custom
+    # child elements inside it.
+    #
+    # For AUTHN_CONTEXT_DECL: The standard AuthnContextClassRef is always emitted.
+    # The extension receives the AuthnContext builder to add AuthnContextDecl or
+    # other child elements alongside it.
     #
     # Example (AuthnContextDecl extension):
     #

--- a/lib/saml_idp/controller.rb
+++ b/lib/saml_idp/controller.rb
@@ -71,6 +71,7 @@ module SamlIdp
       asserted_attributes_opts = opts[:attributes] || nil
       signed_assertion_opts = opts[:signed_assertion].nil? ? true : opts[:signed_assertion]
       compress_opts = opts[:compress] || false
+      assertion_extension = opts[:assertion_extension] || nil
 
       SamlResponse.new(
         reference_id: reference_id,
@@ -92,7 +93,8 @@ module SamlIdp
         asserted_attributes_opts: asserted_attributes_opts,
         signed_message_opts: signed_message_opts,
         signed_assertion_opts: signed_assertion_opts,
-        compression_opts: compress_opts
+        compression_opts: compress_opts,
+        assertion_extension: assertion_extension
       ).build
     end
 

--- a/lib/saml_idp/saml_response.rb
+++ b/lib/saml_idp/saml_response.rb
@@ -24,6 +24,7 @@ module SamlIdp
     attr_accessor :signed_message_opts
     attr_accessor :signed_assertion_opts
     attr_accessor :compression_opts
+    attr_accessor :assertion_extension
 
     def initialize(
       reference_id:,
@@ -45,7 +46,8 @@ module SamlIdp
       asserted_attributes_opts: nil,
       signed_message_opts: false,
       signed_assertion_opts: true,
-      compression_opts: false
+      compression_opts: false,
+      assertion_extension: nil
     )
 
       self.reference_id = reference_id
@@ -70,6 +72,7 @@ module SamlIdp
       self.name_id_formats_opts = name_id_formats_opts
       self.asserted_attributes_opts = asserted_attributes_opts
       self.compression_opts = compression_opts
+      self.assertion_extension = assertion_extension
     end
 
     def build
@@ -128,7 +131,8 @@ module SamlIdp
           encryption_opts: encryption_opts,
           session_expiry: session_expiry,
           name_id_formats_opts: name_id_formats_opts,
-          asserted_attributes_opts: asserted_attributes_opts
+          asserted_attributes_opts: asserted_attributes_opts,
+          assertion_extension: assertion_extension
         )
     end
   end

--- a/spec/lib/saml_idp/assertion_extension_spec.rb
+++ b/spec/lib/saml_idp/assertion_extension_spec.rb
@@ -1,0 +1,47 @@
+require 'spec_helper'
+
+module SamlIdp
+  describe AssertionExtension do
+    describe "extension point constants" do
+      it "defines SUBJECT_CONFIRMATION_DATA_EXTENSION_POINT" do
+        expect(described_class::SUBJECT_CONFIRMATION_DATA_EXTENSION_POINT).to eq("SubjectConfirmationData")
+      end
+
+      it "defines AUTHN_CONTEXT_DECL_EXTENSION_POINT" do
+        expect(described_class::AUTHN_CONTEXT_DECL_EXTENSION_POINT).to eq("AuthnContextDecl")
+      end
+    end
+
+    describe "#initialize" do
+      it "sets extension_point" do
+        extension = described_class.new(described_class::AUTHN_CONTEXT_DECL_EXTENSION_POINT)
+        expect(extension.extension_point).to eq("AuthnContextDecl")
+      end
+    end
+
+    describe "#build" do
+      it "raises when not overridden" do
+        extension = described_class.new(described_class::AUTHN_CONTEXT_DECL_EXTENSION_POINT)
+        context = double("builder context")
+        expect { extension.build(context) }.to raise_error(/#{described_class} must implement build method/)
+      end
+    end
+
+    describe "subclass implementing build" do
+      let(:extension_class) do
+        Class.new(described_class) do
+          def build(context)
+            context.CustomElement "custom_value"
+          end
+        end
+      end
+
+      it "invokes build with the builder context" do
+        extension = extension_class.new(described_class::AUTHN_CONTEXT_DECL_EXTENSION_POINT)
+        context = double("builder context")
+        expect(context).to receive(:CustomElement).with("custom_value")
+        extension.build(context)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

This PR adds an **AssertionExtension** hook so consumers of `saml_idp` can extend the SAML assertion XML at two specification-defined extension points: **SubjectConfirmationData** and **AuthnContextDecl**. When no extension is provided, behavior is unchanged and the assertion is built exactly as today.

## Motivation

Some IdP deployments need to include custom XML in the assertion—for example, device trust or zero-trust context inside `<AuthnContextDecl>`, or extra confirmation data inside `<SubjectConfirmationData>`. The SAML 2.0 Core spec explicitly allows arbitrary elements/attributes at these points (Sections 2.4.1.2 and 2.7.2.2), but the gem currently has no way to inject them without forking. This feature provides a small, optional API to do that.

## Extension points

| Constant | SAML location | Use case |
|----------|--------------|----------|
| `AssertionExtension::SUBJECT_CONFIRMATION_DATA_EXTENSION_POINT` | Inside `<SubjectConfirmation>` | Custom confirmation data; extension emits `<SubjectConfirmationData>` (with standard attributes when using bearer) and any extra elements/attributes. |
| `AssertionExtension::AUTHN_CONTEXT_DECL_EXTENSION_POINT` | Inside `<AuthnContext>`, after `<AuthnContextClassRef>` | Custom authn context; extension adds `<AuthnContextDecl>`, `<AuthnContextDeclRef>`, or other AuthnContext children. |

## Usage

**1. Define a subclass** that implements `#build(context)`. The `context` is a Builder block for either the SubjectConfirmation element (SubjectConfirmationData extension) or the AuthnContext element (AuthnContextDecl extension).

```ruby
# Example: add device/zero-trust context via AuthnContextDecl
class MyAuthnContextExtension < SamlIdp::AssertionExtension
  def initialize
    super(SamlIdp::AssertionExtension::AUTHN_CONTEXT_DECL_EXTENSION_POINT)
  end

  def build(context)
    context.AuthnContextDecl do |builder|
      builder.AuthenticationContextDeclaration xmlns: "urn:my_org:saml:2.0:Device" do |decl|
        decl.Extension do |ext|
          ext.Device xmlns: "urn:my_org:saml:2.0:ZeroTrust", ID: "..." do |device|
            device.Trust do |trust|
              trust.Data Name: "Managed", Value: true
              trust.Data Name: "Compliant", Value: true
            end
          end
        end
      end
    end
  end
end
```

**2. Pass the extension** when encoding the authn response (e.g. in your IdP controller):

```ruby
encode_authn_response(principal, assertion_extension: MyAuthnContextExtension.new)
# or
encode_authn_response(principal, assertion_extension: MySubjectConfirmationDataExtension.new)
```

If `assertion_extension` is omitted or `nil`, the assertion is built with the current default behavior (no custom XML).

## API surface

- **New file:** `lib/saml_idp/assertion_extension.rb` — base class with `extension_point` and abstract `#build(context)`.
- **Controller:** `encode_authn_response(principal, opts)` accepts optional `opts[:assertion_extension]`.
- **SamlResponse / AssertionBuilder:** Optional `assertion_extension` is threaded through and used only when present and when the extension’s `extension_point` matches the current build step.

All new parameters are optional and default to `nil`; existing callers are unaffected.

## Backward compatibility

- **Fully backward compatible.** If `assertion_extension` is not passed, the generated assertion XML is identical to the current implementation.
- No changes to method signatures other than adding an optional keyword argument.

## SAML 2.0 alignment

The two extension points correspond to:

- **SubjectConfirmationData** — Core spec 2.4.1.2 allows arbitrary namespace-qualified attributes and arbitrary child elements inside `<SubjectConfirmationData>`.
- **AuthnContextDecl** — Core spec 2.7.2.2 allows `<AuthnContextDecl>` (and related elements) inside `<AuthnContext>` alongside `<AuthnContextClassRef>`.

We always emit `<AuthnContextClassRef>` first; the extension then adds declaration content. For SubjectConfirmationData, the extension is responsible for emitting `<SubjectConfirmationData>` (including standard attributes like `NotOnOrAfter`, `Recipient`, `InResponseTo` for bearer) and any custom content, so that standard SPs still validate the assertion.

## Testing

- `spec/lib/saml_idp/assertion_extension_spec.rb` — base class behavior, extension point constants, and a subclass that implements `#build`.
- Existing `assertion_builder_spec`, `saml_response_spec`, and `controller_spec` remain valid; the default (no extension) path is unchanged.

## Checklist

- [x] New behavior is opt-in and backward compatible.
- [x] Extension points align with SAML 2.0 Core (SubjectConfirmationData, AuthnContext).
- [x] Tests added for `AssertionExtension`; existing specs still pass with no extension.