### PR TITLE
Add SHA1 support to `Fingerprint.certificate_digest`

### DIFF
--- a/lib/saml_idp/fingerprint.rb
+++ b/lib/saml_idp/fingerprint.rb
@@ -7,6 +7,8 @@ module SamlIdp
 
     def self.digest_sha_class(sha_size)
       case sha_size
+      when :sha1
+        Digest::SHA1
       when :sha256
         Digest::SHA256
       when :sha512

--- a/spec/lib/saml_idp/fingerprint_spec.rb
+++ b/spec/lib/saml_idp/fingerprint_spec.rb
@@ -4,10 +4,24 @@ module SamlIdp
   describe Fingerprint do
     describe "certificate_digest" do
       let(:cert) { sp_x509_cert }
-      let(:fingerprint) { "a2:cb:f6:6b:bc:2a:33:b9:4f:f3:c3:7e:26:a4:21:cd:41:83:ef:26:88:fa:ba:71:37:40:07:3e:d5:76:04:b7" }
 
-      it "returns the fingerprint string" do
-        expect(Fingerprint.certificate_digest(cert, :sha256)).to eq(fingerprint)
+      it "returns a SHA1 fingerprint" do
+        fingerprint = Fingerprint.certificate_digest(cert, :sha1)
+        expect(fingerprint).to match(/\A([0-9a-f]{2}:){19}[0-9a-f]{2}\z/)
+      end
+
+      it "returns a SHA256 fingerprint" do
+        expected = "a2:cb:f6:6b:bc:2a:33:b9:4f:f3:c3:7e:26:a4:21:cd:41:83:ef:26:88:fa:ba:71:37:40:07:3e:d5:76:04:b7"
+        expect(Fingerprint.certificate_digest(cert, :sha256)).to eq(expected)
+      end
+
+      it "returns a SHA512 fingerprint" do
+        fingerprint = Fingerprint.certificate_digest(cert, :sha512)
+        expect(fingerprint).to match(/\A([0-9a-f]{2}:){63}[0-9a-f]{2}\z/)
+      end
+
+      it "raises for unsupported algorithms" do
+        expect { Fingerprint.certificate_digest(cert, :md5) }.to raise_error(ArgumentError, /Unsupported sha size parameter/)
       end
     end
   end


### PR DESCRIPTION
## Summary

Add `:sha1` support to `SamlIdp::Fingerprint.certificate_digest` so the helper can generate fingerprints that match the verification logic already used in `SignedDocument#validate`.

## Problem

Before this change, `Fingerprint.certificate_digest` supported only `:sha256` and `:sha512`.

That did not match the behavior in `SignedDocument#validate`, which compares:

- a fingerprint derived from the XML document's `<ds:DigestMethod>`
- a SHA1 fingerprint fallback computed unconditionally

In practice, this meant SHA1 fingerprints were already accepted during validation, but the helper could not generate them.

This was especially inconsistent because `Fingerprint.certificate_digest(cert)` falls back to `SamlIdp.config.algorithm`, and the default configured algorithm is already `:sha1`.

As a result, the helper's default path could raise `ArgumentError` even though SHA1 fingerprints are valid inputs for request validation.

## Fix

Add `:sha1` to `Fingerprint.digest_sha_class`, mapped to `Digest::SHA1`.

This aligns the fingerprint helper with the existing validation behavior in `xml_security.rb`, which already uses SHA1 as a supported fingerprint comparison path.

## Testing

Expand `Fingerprint` specs to cover:

- SHA1 fingerprints
- SHA256 fingerprints
- SHA512 fingerprints
- unsupported algorithms raising `ArgumentError`

## Notes

Using SHA1 here is for certificate identity matching, not for signature security. Signature verification still happens separately in `validate_doc` using the algorithm declared by the XML signature.